### PR TITLE
ljudspelare utan jquery m.m

### DIFF
--- a/layouts/avsnitt/single.html
+++ b/layouts/avsnitt/single.html
@@ -12,16 +12,16 @@
           <source src="{{ .Params.audiofile }}" type="audio/mpeg">
             Your browser does not support the audio element.
         </audio>
-        </div>
-        {{ end }}
-
-        {{ if .Params.audiofile }}
-        <span class="post-download"><a href="{{ .Params.audiofile }}">Ladda ner (mp3)</a></span>
-        {{ end }}
-
-        {{ .Content }}
-
       </div>
+      {{ end }}
+
+      {{ if .Params.audiofile }}
+      <span class="post-download"><a href="{{ .Params.audiofile }}">Ladda ner (mp3)</a></span>
+      {{ end }}
+
+      {{ .Content }}
+
     </div>
+  </div>
   </body>
-  </html>
+</html>

--- a/layouts/avsnitt/single.html
+++ b/layouts/avsnitt/single.html
@@ -8,17 +8,20 @@
 
       {{ if .Params.libsynid }}
       <div class="post-player">
-<iframe style="border: none" src="//html5-player.libsyn.com/embed/episode/id/{{ .Params.libsynid }}/height/45/width/300/theme/standard-mini/direction/no/autoplay/no/autonext/no/thumbnail/no/preload/no/no_addthis/no/" height="45" width="300" scrolling="no"  allowfullscreen webkitallowfullscreen mozallowfullscreen oallowfullscreen msallowfullscreen></iframe>
+        <audio controls>
+          <source src="{{ .Params.audiofile }}" type="audio/mpeg">
+            Your browser does not support the audio element.
+        </audio>
+        </div>
+        {{ end }}
+
+        {{ if .Params.audiofile }}
+        <span class="post-download"><a href="{{ .Params.audiofile }}">Ladda ner (mp3)</a></span>
+        {{ end }}
+
+        {{ .Content }}
+
       </div>
-      {{ end }}
-
-      {{ if .Params.audiofile }}
-      <span class="post-download"><a href="{{ .Params.audiofile }}">Ladda ner (mp3)</a></span>
-      {{ end }}
-
-      {{ .Content }}
-
     </div>
-  </div>
   </body>
-</html>
+  </html>

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -9,7 +9,10 @@
         <span class="post-date">{{ .Page.Date.Format "2006-01-02 15:04" }}</span>
       {{ if .Page.Params.libsynid }}
       <div class="post-player">
-<iframe style="border: none" src="//html5-player.libsyn.com/embed/episode/id/{{ .Page.Params.libsynid }}/height/45/width/300/theme/standard-mini/direction/no/autoplay/no/autonext/no/thumbnail/no/preload/no/no_addthis/no/" height="45" width="300" scrolling="no"  allowfullscreen webkitallowfullscreen mozallowfullscreen oallowfullscreen msallowfullscreen></iframe>
+        <audio controls>
+          <source src="{{ .Params.audiofile }}" type="audio/mpeg">
+            Your browser does not support the audio element.
+        </audio>
       </div>
       {{ end }}
 


### PR DESCRIPTION
Eftersom libsyn ändå kör html5 spelare. Går lika bra att bara köra upp spelaren direkt i ren HTML.
http://www.w3schools.com/html/html5_audio.asp
Den kanske dock laddar in nån form av tracking, aja det där har ni bättre koll på...
