### PR TITLE
Ep 66 info, correct link for Procera Networks

### DIFF
--- a/content/avsnitt/66.md
+++ b/content/avsnitt/66.md
@@ -47,7 +47,7 @@ Avsnittet sponsras av [Procera](http://www.proceranetworks.com/index.php), som [
 * [BSD](http://en.wikipedia.org/wiki/Berkeley_Software_Distribution) - familj av Unix-lika operativsystem
 * [JVM](http://en.wikipedia.org/wiki/Java_virtual_machine) - Javas virtuella maskin
 * Vi snackade nyss om att det är arbetstagarens marknad för utvecklare just nu
-* [Procera networks]((http://www.proceranetworks.com/index.php)) - veckans sponsor
+* [Procera networks](http://www.proceranetworks.com/index.php) - veckans sponsor
 * [Procera söker webbapplikationsutvecklare](http://bit.ly/proceranetworks), bland annat
 * [Ember](http://emberjs.com)
 * [Backbone](http://backbonejs.org)


### PR DESCRIPTION
Two pair of parantheses instead of just one pair made the anchor link go boom!
