### PR TITLE
Bruten länk CodeNight

### DIFF
--- a/content/avsnitt/90.md
+++ b/content/avsnitt/90.md
@@ -28,7 +28,7 @@ Har du kommentarer, frågor eller tips? Vi är [@kodnsack](https://www.twitter.c
 ## Länkar ##
 * [Cloudnet](http://www.cloudnet.se)
 * [VPS](http://en.wikipedia.org/wiki/Virtual_private_server) - virtual private server
-* [Code night](kampanj.idg.se/codenight)
+* [Code night](http://www.codenight.se/)
 * [IDG](http://www.idg.se/)
 * [Internet of things](http://en.wikipedia.org/wiki/Internet_of_Things)
 * [Intels Edison](http://www.intel.com/content/www/us/en/do-it-yourself/edison.html)


### PR DESCRIPTION
Märkte att länken för Code Night var bruten. Märkte också att de har codenight.se från bekräftelse mailet.