### PR TITLE
Fixa livepodd mejl länk

### DIFF
--- a/content/avsnitt/224.md
+++ b/content/avsnitt/224.md
@@ -17,7 +17,7 @@ Först och inte minst en liten pepp inför hösten: den 3 oktober blir det after
 
 Vi håller till på Hobo på Brunkebergstorg 4. Dörrarna öppnas vid 17, någonstans vid 18 poddar vi och sedan hänger vi alla kvar och tar valfritt antal valfria drycker och snackar så länge vi orkar.
 
-Vi hoppas att *du* vill komma, och att du tar med dig en bekant eller två! Antalet platser är begränsat, så skicka iväg ett mejl så snart det bara går till [livepodd@gmail.com](mailto:lovepodd@gmail.com) med namn, företag och om du tar med dig någon.
+Vi hoppas att *du* vill komma, och att du tar med dig en bekant eller två! Antalet platser är begränsat, så skicka iväg ett mejl så snart det bara går till [livepodd@gmail.com](mailto:livepodd@gmail.com) med namn, företag och om du tar med dig någon.
 
 Ett stort tack till [Cloudnet](http://www.cloudnet.se) som sponsrar vår [VPS](http://en.wikipedia.org/wiki/Virtual_private_server)!
 
@@ -33,10 +33,10 @@ Gillar du Kodsnack får du hemskt gärna [recensera oss i iTunes](http://itunes.
 * 57:18: Avslutning
 
 ## Länkar ##
-* [Anmäl dig](mailto:lovepodd@gmail.com) till after work och livepodd den 3 oktober!
+* [Anmäl dig](mailto:livepodd@gmail.com) till after work och livepodd den 3 oktober!
 * [Suse](https://www.suse.com/) - sponsrar kvällen
 * [Hobo](https://hobo.se/sv/) - lokalen för kvällen
-* [livepodd@gmail.com](mailto:lovepodd@gmail.com) - anmäl dig med namn, företag och om du tar med dig någon mer
+* [livepodd@gmail.com](mailto:livepodd@gmail.com) - anmäl dig med namn, företag och om du tar med dig någon mer
 * [Ola Petersson på Twitter](https://twitter.com/gotoOla) och [webben](http://olapetersson.se/)
 * [Squeed](http://www.squeed.com/)
 * [Java community process](https://www.jcp.org/en/home/index)

--- a/content/avsnitt/225.md
+++ b/content/avsnitt/225.md
@@ -21,7 +21,7 @@ En pepp inför hösten: den 3 oktober blir det after work och livepodd sponsrad 
 
 Vi håller till på Hobo på Brunkebergstorg 4. Dörrarna öppnas vid 17, någonstans vid 18 poddar vi och sedan hänger vi alla kvar och tar valfritt antal valfria drycker och snackar så länge vi orkar.
 
-Vi hoppas att *du* vill komma, och att du tar med dig en bekant eller två! Antalet platser är begränsat, så skicka iväg ett mejl så snart det bara går till [livepodd@gmail.com](mailto:lovepodd@gmail.com) med namn, företag och om du tar med dig någon.
+Vi hoppas att *du* vill komma, och att du tar med dig en bekant eller två! Antalet platser är begränsat, så skicka iväg ett mejl så snart det bara går till [livepodd@gmail.com](mailto:livepodd@gmail.com) med namn, företag och om du tar med dig någon.
 
 Ett stort tack till [Cloudnet](http://www.cloudnet.se) som sponsrar vår [VPS](http://en.wikipedia.org/wiki/Virtual_private_server)!
 
@@ -38,10 +38,10 @@ Gillar du Kodsnack får du hemskt gärna [recensera oss i iTunes](http://itunes.
 * 33:20: Poddtips
 
 ## Länkar ##
-* [Anmäl dig](mailto:lovepodd@gmail.com) till after work och livepodd den 3 oktober!
+* [Anmäl dig](mailto:livepodd@gmail.com) till after work och livepodd den 3 oktober!
 * [Suse](https://www.suse.com/) - sponsrar kvällen
 * [Hobo](https://hobo.se/sv/) - lokalen för kvällen
-* [livepodd@gmail.com](mailto:lovepodd@gmail.com) - anmäl dig med namn, företag och om du tar med dig någon mer
+* [livepodd@gmail.com](mailto:livepodd@gmail.com) - anmäl dig med namn, företag och om du tar med dig någon mer
 * [Advent of code](http://adventofcode.com/) - bidra gärna till [Kodsnacks repo med lösningar](https://github.com/kodsnack/advent_of_code_2016)!
 * [Esoteriska programmeringsspråk](https://en.wikipedia.org/wiki/Esoteric_programming_language#FALSE)
 * [dlofstrom](https://github.com/dlofstrom) på Github

--- a/content/avsnitt/226.md
+++ b/content/avsnitt/226.md
@@ -20,7 +20,7 @@ En pepp inför hösten: den 3 oktober blir det after work och livepodd sponsrad 
 
 Vi håller till på Hobo på Brunkebergstorg 4. Dörrarna öppnas vid 17, någonstans vid 18 poddar vi och sedan hänger vi alla kvar och tar valfritt antal valfria drycker och snackar så länge vi orkar.
 
-Vi hoppas att *du* vill komma, och att du tar med dig en bekant eller två! Antalet platser är begränsat, så skicka iväg ett mejl så snart det bara går till [livepodd@gmail.com](mailto:lovepodd@gmail.com) med namn, företag och om du tar med dig någon.
+Vi hoppas att *du* vill komma, och att du tar med dig en bekant eller två! Antalet platser är begränsat, så skicka iväg ett mejl så snart det bara går till [livepodd@gmail.com](mailto:livepodd@gmail.com) med namn, företag och om du tar med dig någon.
 
 Ett stort tack till [Cloudnet](http://www.cloudnet.se) som sponsrar vår [VPS](http://en.wikipedia.org/wiki/Virtual_private_server)!
 
@@ -40,10 +40,10 @@ Gillar du Kodsnack får du hemskt gärna [recensera oss i iTunes](http://itunes.
 * [Galera](http://galeracluster.com/)
 * [Postgres](https://en.wikipedia.org/wiki/PostgreSQL) - Postgresql
 * [Susecon](https://www.susecon.com/)
-* [Anmäl dig](mailto:lovepodd@gmail.com) till after work och livepodd den 3 oktober!
+* [Anmäl dig](mailto:livepodd@gmail.com) till after work och livepodd den 3 oktober!
 * [Suse](https://www.suse.com/) - sponsrar kvällen
 * [Hobo](https://hobo.se/sv/) - lokalen för kvällen
-* [livepodd@gmail.com](mailto:lovepodd@gmail.com) - anmäl dig med namn, företag och om du tar med dig någon mer
+* [livepodd@gmail.com](mailto:livepodd@gmail.com) - anmäl dig med namn, företag och om du tar med dig någon mer
 * [Under utveckling, avsnitt 11](http://www.timeedit.com/poddavsnitt-11-arrangera-och-ga-pa-konferenser/) - också om att arrangera och gå på konferenser
 * [Ship it](https://shipitconf.org/)
 * [Trellotavlan för Clusterlabs summit](https://trello.com/b/LNUrtV1Q/clusterlabs-summit-2017)

--- a/content/avsnitt/227.md
+++ b/content/avsnitt/227.md
@@ -22,7 +22,7 @@ Don't assume things you want will happen - back things you want to succeed!
 
 We'll occupy Hobo at Brunkebergstorg 4. Doors open at 17, the pod commences somewhere around 18, and then we talk code, life, the universe, and everything and have some nice drinks for as long as we like.
 
-We hope to see *you* there, and that you bring along a friend or two! The number of seats are limited, so send an email as soon as possible to [livepodd@gmail.com](mailto:lovepodd@gmail.com) with your name, company and if you're bringing anyone along. -->
+We hope to see *you* there, and that you bring along a friend or two! The number of seats are limited, so send an email as soon as possible to [livepodd@gmail.com](mailto:livepodd@gmail.com) with your name, company and if you're bringing anyone along. -->
 
 Thank you [Cloudnet](http://www.cloudnet.se) for sponsoring our [VPS](http://en.wikipedia.org/wiki/Virtual_private_server)!
 
@@ -31,10 +31,10 @@ Comments, questions or tips? We are [@kodsnack](https://www.twitter.com/kodsnack
 If you enjoy Kodsnack we would love a [review in iTunes](http://itunes.apple.com/se/podcast/kodsnack/id561631498?l=en)!
 
 ## Links ##
-<!--  [Sign up](mailto:lovepodd@gmail.com) for after work och live pod October 3rd!
+<!--  [Sign up](mailto:livepodd@gmail.com) for after work och live pod October 3rd!
 * [Suse](https://www.suse.com/) - sponsors the evening
 * [Hobo](https://hobo.se/sv/) - the location of the evening
-* [livepodd@gmail.com](mailto:lovepodd@gmail.com) - sign up with name, company, and tell us if you're bringing anyone along -->
+* [livepodd@gmail.com](mailto:livepodd@gmail.com) - sign up with name, company, and tell us if you're bringing anyone along -->
 * [Craig on Github](https://github.com/trogdoro)
 * [Xiki](http://xiki.org/)
 * [The 2014 Xiki Kickstarter](https://www.kickstarter.com/projects/xiki/xiki-the-command-revolution)


### PR DESCRIPTION
Det ser ut som att mailto länkarna för livepodd pekar l**o**vepodd och inte `livepodd@gmail.com` som det troligen var tänkt.