### PR TITLE
Pseudo-automated fix for international page and feed.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,9 +2,12 @@
 
 all: deploy
 
-serve:
+international:
+	grep -l "^english\s\?=\s\?true" content/avsnitt/*.md | xargs cp -ft content/international/
+
+serve: international
 	@hugo server --theme=kodsnack --buildDrafts --watch
 
-deploy:
+deploy: international
 	@hugo --theme=kodsnack --buildFuture --buildExpired --enableGitInfo --logFile /mnt/persist/hugo.log -d ${DEST}
 	@hugo --theme=kodsnack -D --buildFuture --buildExpired --enableGitInfo --logFile /mnt/persist/hugo.log -d ${BETA_DEST}

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 all: deploy
 
 international:
-	grep -l "^english\s\?=\s\?true" content/avsnitt/*.md | xargs cp -ft content/international/
+	grep -l "^english\s\?=\s\?true" content/avsnitt/*.md | xargs -I args cp -f args content/international/
 
 serve: international
 	@hugo server --theme=kodsnack --buildDrafts --watch

--- a/content/international/134.md
+++ b/content/international/134.md
@@ -1,0 +1,83 @@
++++
+date = 2015-12-22T17:26:14Z
+draft = false
+title = "Kodsnack 134 - Allowed to be a beginner again"
+slug = "134"
+aliases = ["/blog/2015/12/22/134"]
+categories = ["avsnitt"]
+audiofile = "https://traffic.libsyn.com/kodsnack/134.mp3"
+libsynid = "4028223"
+english = true
+audiosize = "22070076"
+audiolength = "43:50"
++++
+
+Fredrik talks to [Rachel Reese](http://rachelree.se/about/) about F#, Xamarin, the [the MIT study](http://rachelree.se/the-mit-study/) (on diversity, sexism and career for women faculty at MIT) and related topics. We also cover good communities and being allowed (by yourself and others) to be a beginner.
+
+This episode was recorded during the developer conference [Øredev 2015](https://vimeo.com/144824775), where Rachel gave [two](https://vimeo.com/144692770) [talks](https://vimeo.com/144824775).
+
+Thank you [Cloudnet](http://www.cloudnet.se) for sponsoring our [VPS](http://en.wikipedia.org/wiki/Virtual_private_server)!
+
+Comments, questions or tips? We are [@kodsnack](https://www.twitter.com/kodsnack), [@tobiashieta](https://www.twitter.com/tobiashieta), [@iskrig](https://www.twitter.com/iskrig) och [@bjoreman](https://www.twitter.com/bjoreman) on Twitter, have a [page on Facebook](https://www.facebook.com/kodsnack) and can be emailed on [info@kodsnack.se](mailto:info@kodsnack.se) if you want to write something longer. We read everything you send.
+
+If you like Kodsnack we would love a [review in iTunes](http://itunes.apple.com/se/podcast/kodsnack/id561631498?l=en)!
+
+## Links ##
+* [F#](https://en.wikipedia.org/wiki/F_Sharp_%28programming_language%29)
+* [TechEd](https://en.wikipedia.org/wiki/TechEd)
+* [The project Euler problems](https://projecteuler.net/about)
+* [Skills matter](https://skillsmatter.com/)
+* [The progressive F# tutorials](https://skillsmatter.com/explore?q=progressive+f%23+tutorials)
+* [The F# koans](http://tryfs.net/snippets/snippet-bG)
+* [Koan](https://en.wikipedia.org/wiki/K%C5%8Dan)
+* [Don Syme](https://en.wikipedia.org/wiki/Don_Syme)
+* [Type providers](https://msdn.microsoft.com/en-us/library/hh156509.aspx)
+* [The World bank type provider](http://fsharp.github.io/FSharp.Data/library/WorldBank.html)
+* [Type inference](https://en.wikipedia.org/wiki/Type_inference)
+* [Swift](https://en.wikipedia.org/wiki/Swift_%28programming_language%29)
+* [Jet](https://jet.com/) - where Rachel works
+* [Cross-cutting concerns](https://en.wikipedia.org/wiki/Cross-cutting_concern)
+* [Pipelines in F#](https://en.wikibooks.org/wiki/F_Sharp_Programming/Higher_Order_Functions#The_.7C.3E_Operator)
+* [Powershell](https://en.wikipedia.org/wiki/Windows_PowerShell)
+* [Rachel's blog post about rewriting an application from C# to F#](http://rachelree.se/rewriting-from-c-into-f/)
+* [Discriminated union](https://msdn.microsoft.com/en-us/library/dd233226.aspx)
+* [Xamarin](https://en.wikipedia.org/wiki/Xamarin)
+* [Haskell](https://en.wikipedia.org/wiki/Haskell_%28programming_language%29)
+* [ML](https://en.wikipedia.org/wiki/ML_%28programming_language%29)
+* [Ocaml](https://en.wikipedia.org/wiki/OCaml)
+* [Generics](https://en.wikipedia.org/wiki/Generic_programming)
+* [John Harrop](http://fsharpnews.blogspot.se/2012/05/f-vs-c-performance.html) - F# vs C++ performance
+* [Mono](https://en.wikipedia.org/wiki/Mono_%28software%29)
+* [Minesweeper](https://en.wikipedia.org/wiki/Minesweeper_%28video_game%29)
+* [The MIT study](http://rachelree.se/the-mit-study/)
+* [STEM](https://en.wikipedia.org/wiki/Science,_Technology,_Engineering,_and_Mathematics) - Science, technology, engineering, and mathematics
+* [Women in science and engineering](https://en.wikipedia.org/wiki/WISE_Campaign)
+* [Rosalyn Franklin](https://en.wikipedia.org/wiki/Rosalind_Franklin) - contributed to the understanding of DNA, RNA, viruses, coal, and graphite
+* [Physical review](https://en.wikipedia.org/wiki/Physical_Review)
+* [Cocoaheads](http://cocoaheads.org/)
+* [Monad](https://en.wikipedia.org/wiki/Monad_%28functional_programming%29)
+* [The petrie multiplier](http://blog.ian.gent/2013/10/the-petrie-multiplier-why-attack-on.html) - the blog post Rachel mentioned
+
+## Titles ##
+* Some big American conference
+* I figured out what a script file did
+* I'm definitely not advanced
+* I just sat there amazed
+* The magic grandfather
+* It's a lot of little things
+* It could have been like this all the time
+* A natural next step
+* A perceived lack of support
+* A discriminated union
+* I love to hate Xcode
+* Surely it's slow?
+* Release the Herrup
+* Package it in a view and pretend it's native
+* Exactly like the study said it would
+* Do I want this now?
+* The most depressing thing I've ever heard
+* Too senior to be encouraged anymore
+* To be allowed to be a beginner again
+* They thought I had been speaking
+* People still want me to speak, apparently
+* There has been progress everywhere else

--- a/content/international/136.md
+++ b/content/international/136.md
@@ -1,0 +1,61 @@
++++
+date = 2015-12-30T17:26:14Z
+draft = false
+title = "Kodsnack 136 - You can do all of this with the brain of a sesame seed"
+slug = "136"
+aliases = ["/blog/2015/12/30/136"]
+categories = ["avsnitt"]
+audiofile = "https://traffic.libsyn.com/kodsnack/136.mp3"
+libsynid = "4045909"
+english = true
+audiosize = "20950662"
+audiolength = "39:19"
++++
+
+This episode is a little special. It is kind of bonus material for the [Øredev conference](http://www.oredev.org) of 2015. In it, you will hear Tim Urban and Torill Kornfeldt discuss artificial intelligence, life extension and the differing mindsets of technology and biology.
+
+Tim Urban is the writer of [Wait but why](http://waitbutwhy.com/), a fantastic website of deep dives into topics like [artificial intelligence](http://waitbutwhy.com/2015/01/artificial-intelligence-revolution-1.html), [Tesla and SpaceX](http://waitbutwhy.com/2015/05/elon-musk-the-worlds-raddest-man.html) but also softer topics like [procrastination](http://waitbutwhy.com/2013/10/why-procrastinators-procrastinate.html) and [the fear of what other people think](http://waitbutwhy.com/2014/06/taming-mammoth-let-peoples-opinions-run-life.html).
+
+[Torill Kornfeldt](https://twitter.com/vet_Torill) is a biologist and science journalist who is currently working on a book about de-extinction - the bringing back of extinct species.
+
+We call this bonus material because you probably want some background in order to enjoy their conversation to its fullest. We highly recommend watching both their Øredev keynotes, and Tim's ideas are of course well covered on Wait but why as well.
+
+The conversation was recorded on stage at the conference and is also available in [video form](https://www.youtube.com/watch?v=xDu4-o4uFRQ). Unfortunately there is some buzzing in the audio which I've done my best to filter out in this version. That's why it sounds pretty processed. Special thanks to [Stephen Chin](http://steveonjava.com/) of [nighthacking.com](http://nighthacking.com/) for providing all the tech and expertise which made this recording possible!
+
+We are so happy this conversation came together and how it turned out, pure audio quality aside, and we hope you will enjoy it too!
+
+## Links ##
+
+* [Tim's keynote](https://vimeo.com/144847615) - The AI revolution: the road to superintelligence
+* [Torill's keynote](https://vimeo.com/144804778) - The real Jurassic park - rebirth of extinct species
+* [Wait but why](http://waitbutwhy.com/)
+* [Torill on Twitter](https://twitter.com/vet_Torill)
+* [The Øredev conference](http://www.oredev.org)
+* [Neural networks in biology](https://en.wikipedia.org/wiki/Biological_neural_network)
+* [Calculations per second of the brain](http://www.merkle.com/brainLimits.html)
+* [The human brain is "the most complex object in the known universe"](http://www.npr.org/2013/06/14/191614360/decoding-the-most-complex-object-in-the-universe)
+* [Bees killing their queen by heating](https://www.youtube.com/watch?v=1h81E-hlSbQ)
+* [All-nighter](http://www.wikihow.com/Pull-an-All-Nighter)
+* [Ray Kurzweil](https://en.wikipedia.org/wiki/Ray_Kurzweil)
+* [Communicating with octopus](https://en.wikipedia.org/wiki/Cephalopod_intelligence)
+* [Billions of dollars](http://www.wired.com/2014/01/google-buying-way-making-brain-irrelevant/) spent on AI research
+* [Future of life institute](https://en.wikipedia.org/wiki/Future_of_Life_Institute) and [AI safety](https://en.wikipedia.org/wiki/Existential_risk_from_artificial_general_intelligence) research
+* [The oldest organisms in the world](https://en.wikipedia.org/wiki/List_of_longest-living_organisms#Clonal_plant_and_fungi_colonies) are trees
+* [Every animal gets the same number of heartbeats](http://www.npr.org/templates/story/story.php?storyId=12877984)
+* [Cryonics](https://en.wikipedia.org/wiki/Cryonics) and [cryopreservation](https://en.wikipedia.org/wiki/Cryopreservation)
+
+## Titles ##
+
+* You can do all of this with the brain of a sesame seed
+* People both overestimate and underestimate the brain
+* Kill the queen in a hot ball of fire
+* That is so annoying for her
+* Can we just talk about bees?
+* I don't talk to enough biologists
+* Lacking a good definition of intelligence
+* From the drive to get a Nobel price to the drive to go to the toilet
+* We're going to have a huge problem communicating with it
+* The constantly changing hardwarex
+* Every single want is a chemical
+* That good enough-level
+* A completely different take on aging

--- a/content/international/141.md
+++ b/content/international/141.md
@@ -1,0 +1,55 @@
++++
+date = 2016-02-02T05:26:14Z
+draft = false
+title = "Kodsnack 141 - We end up with everybody being better"
+slug = "141"
+aliases = ["/blog/2016/02/02/141"]
+categories = ["avsnitt"]
+audiofile = "https://traffic.libsyn.com/kodsnack/141.mp3"
+libsynid = "4113354"
+english = true
+audiosize = "14790292"
+audiolength = "30:13"
++++
+
+Fredrik talks to [Sallyann Freudenberg](http://www.twitter.com/salFreudenberg) - "Agile/Lean coach and practitioner, psychology of software development researcher, neuro-diversity advocate, ageing punk-rocker." - about her research into pair programming, offices for everyone and how people actually (do not) split work when pair programming.
+
+We also discuss what makes an expert an expert? What are lists and verbalization really good for? Research versus practise and how and what each side can learn from the other. And why the rift is there in the first place. The goals and methods of the two groups are pretty different.
+
+We talked ina surprisingly noisy hotel lobby, so apologies for all the background noise. The conversation is clear enough that further filtering mostly made everything sound worse.
+
+This episode was recorded during the developer conference [Øredev 2015](https://vimeo.com/144824775), where Sallyann gave a [keynote presentation](https://vimeo.com/144658723).
+
+Thank you [Cloudnet](http://www.cloudnet.se) for sponsoring our [VPS](http://en.wikipedia.org/wiki/Virtual_private_server)!
+
+Comments, questions or tips? We are [@kodsnack](https://www.twitter.com/kodsnack), [@tobiashieta](https://www.twitter.com/tobiashieta), [@iskrig](https://www.twitter.com/iskrig) och [@bjoreman](https://www.twitter.com/bjoreman) on Twitter, have a [page on Facebook](https://www.facebook.com/kodsnack) and can be emailed on [info@kodsnack.se](mailto:info@kodsnack.se) if you want to write something longer. We read everything you send.
+
+If you like Kodsnack we would love a [review in iTunes](http://itunes.apple.com/se/podcast/kodsnack/id561631498?l=en)!
+
+## Links ##
+* [Understanding and supporting neurodiversity in software development](https://vimeo.com/144658723) - Sallyann's keynote at Øredev 2015
+* [Sallyann's research](https://salfreudenberg.wordpress.com/publications/)
+* [Etnographic studies](https://en.wikipedia.org/wiki/Ethnography#Communication_studies)
+* [Legitimate peripheral participation](https://en.wikipedia.org/wiki/Legitimate_peripheral_participation)
+* [Laura Plonka](http://www9.open.ac.uk/mct/people/laura.plonka)
+* [Neurodiversity](https://en.wikipedia.org/wiki/Neurodiversity)
+* [The art of thought](https://www.brainpickings.org/2013/08/28/the-art-of-thought-graham-wallas-stages/) - Graham Wallas in 1926 on the four stages of creativity
+* [Daniel Friedman](https://en.wikipedia.org/wiki/Daniel_P._Friedman)
+* [Ivan Moore](http://puttingtheteaintoteam.blogspot.se/) - tea-driven development
+* [Micki Chi](http://chilab.asu.edu/)
+* [Verbal overshadowing](https://en.wikipedia.org/wiki/Verbal_overshadowing)
+* [Cognitive offload](https://en.wikipedia.org/wiki/Distributed_cognition)
+* [Laurent Bossavit - The leprechauns of software engineering](https://leanpub.com/leprechauns)
+
+## Titles ##
+* More about everything
+* Commercial pair programmers
+* The softer, broader stuff
+* The benefits of pair programming
+* We end up with everybody being better
+* Knocking down all the offices with sledge hammers
+* What I'd like to see is a blended environment
+* 14500 pieces of pair programmer dialogue
+* We want to think we're so structured
+* Everybody needs a quiet space from time to time
+* My sample size of one

--- a/content/international/143.md
+++ b/content/international/143.md
@@ -1,0 +1,80 @@
++++
+date = 2016-02-16T05:26:14Z
+draft = false
+title = "Kodsnack 143 - The web standards bug"
+slug = "143"
+aliases = ["/blog/2016/02/16/143"]
+categories = ["avsnitt"]
+audiofile = "https://traffic.libsyn.com/kodsnack/143.mp3"
+libsynid = "4147624"
+english = true
+audiosize = "51078920"
+audiolength = "43:53"
++++
+
+Fredrik talks to [Aaron Gustafson](https://aaron-gustafson.com/) about web standards. His origin story, how he got into web standards. How the standards work and who should get involved. The problems with prefixes and how we use them.
+
+This episode was recorded during the developer conference [Øredev 2015](https://vimeo.com/144824775), where Aaron gave [two](https://vimeo.com/144870932) [talks](https://vimeo.com/144979022).
+
+Thank you [Cloudnet](http://www.cloudnet.se) for sponsoring our [VPS](http://en.wikipedia.org/wiki/Virtual_private_server)!
+
+Comments, questions or tips? We are [@kodsnack](https://www.twitter.com/kodsnack), [@tobiashieta](https://www.twitter.com/tobiashieta), [@iskrig](https://www.twitter.com/iskrig) och [@bjoreman](https://www.twitter.com/bjoreman) on Twitter, have a [page on Facebook](https://www.facebook.com/kodsnack) and can be emailed on [info@kodsnack.se](mailto:info@kodsnack.se) if you want to write something longer. We read everything you send.
+
+If you like Kodsnack we would love a [review in iTunes](http://itunes.apple.com/se/podcast/kodsnack/id561631498?l=en)!
+
+## Links ##
+* [Frameset](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/frameset)
+* [Quark](https://en.wikipedia.org/wiki/QuarkXPress)
+* [Dreamweaver](https://en.wikipedia.org/wiki/Adobe_Dreamweaver)
+* [Fetch](https://en.wikipedia.org/wiki/Fetch_%28FTP_client%29)
+* [Eric Meyer](https://en.wikipedia.org/wiki/Eric_A._Meyer)
+* [DOM level 0](http://www.quirksmode.org/js/dom0.html)
+* [A list apart](http://alistapart.com/about)
+* [Jeffrey Zeldman](https://en.wikipedia.org/wiki/Jeffrey_Zeldman)
+* [XHTML](https://en.wikipedia.org/wiki/XHTML)
+* [COMDEX](https://en.wikipedia.org/wiki/COMDEX)
+* [Molly Holzschlag](https://en.wikipedia.org/wiki/Molly_Holzschlag)
+* [South by southwest](https://en.wikipedia.org/wiki/South_by_Southwest)
+* [Filemaker](https://en.wikipedia.org/wiki/FileMaker)
+* [Jeff Veen](https://twitter.com/veen?lang=sv)
+* [Jen Robbins](https://en.wikipedia.org/wiki/Jennifer_Niederst_Robbins) - [Web design in a nutshell](http://shop.oreilly.com/product/9780596009878.do)
+* [Jeremy Keith](https://adactio.com/)
+* [Andy Budd](http://clearleft.com/is/andy-budd)
+* [Richard Rutter](http://clearleft.com/is/richard-rutter)
+* [Clearleft](http://clearleft.com/)
+* [The web standards project](http://www.webstandards.org/)
+* [Glenda Simms](http://www.webstandards.org/about/members/goodwitch/)
+* [Derek Featherstone](http://www.webstandards.org/about/members/feather/)
+* [W3C](http://www.w3.org/)
+* [TPAC](https://www.w3.org/TPAC/)
+* [Indesign](https://en.wikipedia.org/wiki/Adobe_InDesign)
+* [Pagemaker](https://en.wikipedia.org/wiki/Adobe_PageMaker)
+* [CSS shapes](http://www.html5rocks.com/en/tutorials/shapes/getting-started/)
+* [Web platform incubator community group](https://www.w3.org/community/wicg/)
+* [SVG](https://en.wikipedia.org/wiki/Scalable_Vector_Graphics)
+* [Network information API](https://www.w3.org/TR/netinfo-api/) - seems to have been shut down
+* [Vendor prefixes](https://developer.mozilla.org/en-US/docs/Glossary/Vendor_Prefix)
+* [Edge](https://en.wikipedia.org/wiki/Microsoft_Edge) - Microsoft's successor to Internet explorer
+* [Alex Russell on vendor prefixes](https://medium.com/@slightlylate/doing-science-on-the-web-af26d9be2faa#.6zu2sj3y1) and their problems
+* [WHATWG](https://whatwg.org/) - Web hypertext application technology working group
+* [Web SQL](https://en.wikipedia.org/wiki/Web_SQL_Database)
+* [Firefox phones did not last](http://www.theverge.com/2015/12/8/9872802/mozilla-has-killed-the-firefox-phone)
+* [Zork](https://en.wikipedia.org/wiki/Zork)
+* [Basecamp](https://en.wikipedia.org/wiki/Basecamp_%28software%29)
+* [Harvest](https://en.wikipedia.org/wiki/Harvest_%28software%29)
+* [Adaptive web design](http://adaptivewebdesign.info/2nd-edition/), second edition
+* Aaron's [two](https://vimeo.com/144870932) [talks](https://vimeo.com/144979022)
+
+## Titles ##
+* You're the web standards guy
+* Who falls into web standards and how does it happen?
+* Between midnight and 5 a.m.
+* Things were starting to stabilize a bit on the web
+* The only way to build a solid foundation
+* The web standards bug
+* Before coming to the web
+* In the trenches every day making web pages
+* Help make other specs better
+* Vendor prefixes have bitten us in the ass
+* We don't experience the web the way everyone else does
+* I can't believe I want them to make their ads more accessible

--- a/content/international/157.md
+++ b/content/international/157.md
@@ -1,0 +1,54 @@
++++
+date = 2016-05-24T05:26:14Z
+draft = false
+title = "Kodsnack 157 - I have no idea what a startup is"
+slug = "157"
+aliases = ["/blog/2016/05/24/157"]
+categories = ["avsnitt"]
+audiofile = "https://traffic.libsyn.com/kodsnack/157.mp3"
+libsynid = "4378444"
+english = true
+audiosize = "23257773"
+audiolength = "47:41"
++++
+
+Live on stage at Startup arena 2016 in Gothenburg, Fredrik talks to [Bob Jelica](https://twitter.com/b0bben), Johannes Tveitan and Magnus Gudmundsson and try to nail down just what a startup is and what working for one means.
+
+Thank you [Cloudnet](http://www.cloudnet.se) for sponsoring our [VPS](http://en.wikipedia.org/wiki/Virtual_private_server)!
+
+Comments, questions or tips? We are [@kodsnack](https://www.twitter.com/kodsnack), [@tobiashieta](https://www.twitter.com/tobiashieta), [@iskrig](https://www.twitter.com/iskrig) och [@bjoreman](https://www.twitter.com/bjoreman) on Twitter, have a [page on Facebook](https://www.facebook.com/kodsnack) and can be emailed on [info@kodsnack.se](mailto:info@kodsnack.se) if you want to write something longer. We read everything you send.
+
+If you like Kodsnack we would love a [review in iTunes](http://itunes.apple.com/se/podcast/kodsnack/id561631498?l=en)!
+
+## Länkar ##
+* [Bob Jelica](https://twitter.com/b0bben)
+* [Football addicts](http://www.footballaddicts.com/)
+* [Johannes Tveitan](https://twitter.com/tveitan)
+* [Monocl](http://monocl.com/)
+* [Gothenburg startup hack](http://www.gbgstartuphack.com/)
+* [Magnus Gudmundsson](https://www.linkedin.com/in/magnus-gudmundsson-42346327)
+* [Cyberdada](http://www.cyberdada.com/)
+* [Startup](https://en.wikipedia.org/wiki/Startup_company) - on Wikipedia
+* [TPS reports](https://www.youtube.com/watch?v=Fy3rjQGc6lA)
+* [Jamie Zawinski](https://en.wikipedia.org/wiki/Jamie_Zawinski)
+* [Netscape](https://en.wikipedia.org/wiki/Netscape)
+* [The Netscape dorm](https://www.jwz.org/gruntle/nscpdorm.html)
+* [E.T.](https://en.wikipedia.org/wiki/E.T._the_Extra-Terrestrial_%28video_game%29) - the video game
+
+## Titlar ##
+* I don't do coding anymore
+* I have no idea what a startup is
+* A small company trying to do something
+* Spending someone else's money
+* Does everyone have to disrupt shit?
+* Pivot, come on, pivot
+* Infinite hours for minimum wage
+* You should have started by then
+* We need to burn some people
+* You have passion for this now
+* Real passion is contagious
+* Riding the unicorn
+* Watch out for the unicorn riders
+* The luxury of chasing the dream
+* Suddenly we did know shit
+* Stop disrupting shit

--- a/content/international/166.md
+++ b/content/international/166.md
@@ -1,0 +1,57 @@
++++
+date = 2016-07-26T05:26:14Z
+draft = false
+title = "Kodsnack 166 - On the periphery of the monolith"
+slug = "166"
+aliases = ["/blog/2016/07/26/166"]
+categories = ["avsnitt"]
+audiofile = "https://traffic.libsyn.com/kodsnack/166.mp3"
+libsynid = "4536859"
+english = true
+audiosize = "16375162"
+audiolength = "32:32"
++++
+
+Fredrik talks to [James Turnbull](http://www.twitter.com/kartar) of Kickstarter, Docker and several other companies. Topics range from switching between types of companies and solutions to writing books, documentation and contributing to software in ways other than code. Of course, we also discuss Docker, whether it's succeeded in various ways and where it might be going. Who should be thinking about Docker? How to start thinking about it? Where do you start picking on your monolith to start bringing it into the container future?
+
+This episode was recorded during the developer conference [Øredev 2015](https://vimeo.com/144824775), where James gave a presentation on [Orchestrating Docker](https://vimeo.com/144803754).
+
+Thank you [Cloudnet](http://www.cloudnet.se) for sponsoring our [VPS](http://en.wikipedia.org/wiki/Virtual_private_server)!
+
+Comments, questions or tips? We are [@kodsnack](https://www.twitter.com/kodsnack), [@tobiashieta](https://www.twitter.com/tobiashieta), [@iskrig](https://www.twitter.com/iskrig) och [@bjoreman](https://www.twitter.com/bjoreman) on Twitter, have a [page on Facebook](https://www.facebook.com/kodsnack) and can be emailed on [info@kodsnack.se](mailto:info@kodsnack.se) if you want to write something longer. We read everything you send.
+
+If you like Kodsnack we would love a [review in iTunes](http://itunes.apple.com/se/podcast/kodsnack/id561631498?l=en)!
+
+## Links ##
+* [James Turnbull](http://www.twitter.com/kartar)
+* Docker - the [company](https://www.docker.com/company) and [the software solution](https://en.wikipedia.org/wiki/Docker_%28software%29)
+* [Puppet labs](https://en.wikipedia.org/wiki/Puppet_%28the_company%29)
+* [Public-benefit corporation](https://en.wikipedia.org/wiki/Public-benefit_corporation)
+* [Immutable infrastructure](http://thenewstack.io/a-brief-look-at-immutable-infrastructure-and-why-it-is-such-a-quest/)
+* [Docker swarm](https://docs.docker.com/swarm/)
+* [Docker compose](https://docs.docker.com/compose/)
+* [Kubernetes](http://kubernetes.io/docs/whatisk8s/)
+* [Mesos](http://mesos.apache.org/)
+* [Mesosphere](https://mesosphere.com/)
+* [Elasticsearch](https://en.wikipedia.org/wiki/Elasticsearch)
+* [Memcached](https://en.wikipedia.org/wiki/Memcached)
+* [Redis](https://en.wikipedia.org/wiki/Redis)
+* [Amazon cloudformation](https://aws.amazon.com/cloudformation/)
+* [James' books](https://jamesturnbull.net/#books)
+* [William Gibson](https://en.wikipedia.org/wiki/William_Gibson)
+* [Dennis Ritchie](https://en.wikipedia.org/wiki/Dennis_Ritchie)
+* [Daniel Friedman](https://en.wikipedia.org/wiki/Daniel_P._Friedman)
+* [Vagrant](https://en.wikipedia.org/wiki/Vagrant_%28software%29)
+* [Jekyll](https://en.wikipedia.org/wiki/Jekyll_%28software%29)
+
+## Titles ##
+* A lot of similar paralells
+* The unit of the container
+* A unit of compute
+* I want my code to run somewhere where it makes me money
+* A new way of thinking about architecture
+* On the periphery of the monolith
+* Useful information trapped in the heads of smart people
+* My commits tend to be more documentation than code
+* Aspects of being an engineer
+* A higher level of tolerance and precision

--- a/content/international/167.md
+++ b/content/international/167.md
@@ -1,0 +1,44 @@
++++
+date = 2016-08-02T05:26:14Z
+draft = false
+title = "Kodsnack 167 - You're part of the sample"
+slug = "167"
+aliases = ["/blog/2016/08/02/167"]
+categories = ["avsnitt"]
+audiofile = "https://traffic.libsyn.com/kodsnack/167.mp3"
+libsynid = "4551008"
+english = true
+audiosize = "16341802"
+audiolength = "32:37"
++++
+
+From the podcaster's corner at [Devsum 16](http://www.devsum.se/), Fredrik talks to [Basia Fusinska](http://barbarafusinska.com/) about data science, R and data analysis. We discuss the ethics and science around data science and analysis. All of us are giving out a lot of data all the time, and there are so many aspects worth considering around what and how we give our data away. Briefly, we talk about what impressions we have of the .NET community, an impression which is changing even as we speak.
+
+Thank you [Cloudnet](http://www.cloudnet.se) for sponsoring our [VPS](http://en.wikipedia.org/wiki/Virtual_private_server)!
+
+The Kodsnack book club is coming back! Our next book is the short story [Binti](http://www.tor.com/2015/08/17/excerpts-binti-nnedi-okorafor/) by [Nnedi Okorafor](https://en.wikipedia.org/wiki/Nnedi_Okorafor). It is a short and sweet read and can be found in many places, like [this](http://www.sfbok.se/produkt/binti-148570) and [this](https://www.amazon.com/gp/product/B010GJG4PE/ref=kics_hp_typ_dp).
+
+Comments, questions or tips? We are [@kodsnack](https://www.twitter.com/kodsnack), [@tobiashieta](https://www.twitter.com/tobiashieta), [@iskrig](https://www.twitter.com/iskrig) och [@bjoreman](https://www.twitter.com/bjoreman) on Twitter, have a [page on Facebook](https://www.facebook.com/kodsnack) and can be emailed on [info@kodsnack.se](mailto:info@kodsnack.se) if you want to write something longer. We read everything you send.
+
+If you like Kodsnack we would love a [review in iTunes](http://itunes.apple.com/se/podcast/kodsnack/id561631498?l=en)!
+
+## Links ##
+* [Basia Fusinska](http://barbarafusinska.com/)
+* [PAAS](https://en.wikipedia.org/wiki/Platform_as_a_service) - Platform as a service
+* [SAAS](https://en.wikipedia.org/wiki/Software_as_a_service) - Software as a service
+* [IAAS](https://en.wikipedia.org/wiki/Cloud_computing#Infrastructure_as_a_service_.28IaaS.29) - Infrastructure as a service
+* [Study on gender and code quality on Github](http://www.bbc.com/news/technology-35559439) - raises questions
+* [Github data archive](https://www.githubarchive.org/)
+* [how-old.net](https://how-old.net/)
+* [Our  talk after the Devsum 16 keynote](https://kodsnack.se/159/) is in its own episode
+* [Karl-Henrik Nilsson](http://karl-henrik.se/)'s IOT presentation is unfortunately not available online
+* [R programming language](https://en.wikipedia.org/wiki/R_%28programming_language%29)
+* [Linear reduction algorithms](https://en.wikipedia.org/wiki/L-reduction)
+
+## Titles ##
+* Data solutions architects - whatever that means
+* I'm still figuring out what that means
+* Adding up numbers
+* As scientific as can be
+* You're part of the sample
+* Once you have this Stockholm syndrome

--- a/content/international/175.md
+++ b/content/international/175.md
@@ -1,0 +1,39 @@
++++
+date = 2016-09-27T05:26:14Z
+draft = false
+title = "Kodsnack 175 - It's let me leave work earlier"
+slug = "175"
+aliases = ["/blog/2016/09/27/175"]
+categories = ["avsnitt"]
+audiofile = "https://traffic.libsyn.com/kodsnack/175.mp3"
+libsynid = "4692275"
+english = true
+audiosize = "10559932"
+audiolength = "20:28"
++++
+
+Fredrik talks to [Pete Hunt](https://twitter.com/floydophone) about monoliths, breaking them up and when not to. And of course React, how it came about and how the introduction to the world looked from the inside. How to handle releases of software and working with communication around it. What happens when you go from underdog to being the safe choice?
+
+This episode was recorded during the developer conference [Øredev 2015](https://vimeo.com/144824775), where Pete gave presentations on [monolith-first apps with Node](http://oredev.org/2015/sessions/monolith-first-apps-with-node-js) and [building React backends](http://oredev.org/2015/sessions/building-a-react-js-backend).
+
+Thank you [Cloudnet](http://www.cloudnet.se) for sponsoring our [VPS](http://en.wikipedia.org/wiki/Virtual_private_server)!
+
+Comments, questions or tips? We are [@kodsnack](https://www.twitter.com/kodsnack), [@tobiashieta](https://www.twitter.com/tobiashieta), [@iskrig](https://www.twitter.com/iskrig) och [@bjoreman](https://www.twitter.com/bjoreman) on Twitter, have a [page on Facebook](https://www.facebook.com/kodsnack) and can be emailed on [info@kodsnack.se](mailto:info@kodsnack.se) if you want to write something longer. We read everything you send.
+
+If you like Kodsnack we would love a [review in iTunes](http://itunes.apple.com/se/podcast/kodsnack/id561631498?l=en)!
+
+## Links ##
+* [Pete Hunt](https://twitter.com/floydophone)
+* [Kubernetes](http://kubernetes.io/)
+* [Lee Byron](http://leebyron.com/) and his talk on [Graphql](https://en.wikipedia.org/wiki/GraphQL)
+* [The Graphql introduction talk](https://www.youtube.com/watch?v=WQLzZf34FJ8) from React Europe 2015
+* [Smyte](https://www.smyte.com/) - where Pete currently works
+* [Pete's talk from JSconf EU](https://www.youtube.com/watch?v=x7cQ3mrcKaY) - Rethinking best practises
+* [The future of Javascript MVC frameworks](http://swannodette.github.io/2013/12/17/the-future-of-javascript-mvcs)
+* [React-motion](https://github.com/chenglou/react-motion)
+
+## Titles ##
+* Everyone has a monolith
+* Follow the hype train
+* HTML in my Javascript!
+* It's let me leave work earlier

--- a/content/international/198.md
+++ b/content/international/198.md
@@ -1,0 +1,74 @@
++++
+date = 2017-03-07T05:26:14Z
+draft = false
+title = "Kodsnack 198 - I'm opposed to magic"
+slug = "198"
+aliases = ["/blog/2017/03/07/198"]
+categories = ["avsnitt"]
+audiofile = "https://traffic.libsyn.com/kodsnack/198.mp3"
+libsynid = "5139172"
+english = true
+audiosize = "31339923"
+audiolength = "01:05:18"
++++
+
+This episode is presented in English.
+
+We chat with [Diego Rodriguez-Losada](https://www.twitter.com/diegorlosada) about the C and C++ package manager Conan. Where did it come from, where is it going, the philosophy behind it (very, very pragmatic) and how Tobias has put it to use at Plex. We also move on to package managers and build systems in general. Also: the interesting topic of being magical versus not.
+
+Thanks to [Cloudnet](http://www.cloudnet.se) for sponsoring our [VPS](http://en.wikipedia.org/wiki/Virtual_private_server)!
+
+Comments, questions or tips? We are [@kodsnack](https://www.twitter.com/kodsnack), [@tobiashieta](https://www.twitter.com/tobiashieta), [@iskrig](https://www.twitter.com/iskrig) and [@bjoreman](https://www.twitter.com/bjoreman) on Twitter, have a [page on Facebook](https://www.facebook.com/kodsnack) and can be mailed at [info@kodsnack.se](mailto:info@kodsnack.se) if you want to write something longer. We read everything sent.
+
+If you like Kodsnack, we would love [a review on iTunes](http://itunes.apple.com/se/podcast/kodsnack/id561631498?l=en)!
+
+## Links ##
+* [Diego](https://www.twitter.com/diegorlosada)
+* [Conan](https://www.conan.io)
+* [Jfrog](https://www.jfrog.com/)
+* [Pypi](https://pypi.python.org/pypi)
+* [npm](https://www.npmjs.com/)
+* [Maven](https://en.wikipedia.org/wiki/Apache_Maven)
+* [biicode](https://github.com/biicode/) - a precursor, sort of, to Conan
+* [Modules in C++](http://stackoverflow.com/questions/3596147/c-modules-why-were-they-removed-from-c0x-will-they-be-back-later-on) - still under active discussion
+* [Cargo](https://crates.io/) - the Rust package manager
+* [Conda](https://conda.io/docs/intro.html) - Python package manager
+* [Automake and autotools](https://www.gnu.org/software/automake/manual/html_node/Autotools-Introduction.html)
+* [zlib](https://en.wikipedia.org/wiki/Zlib)
+* [qmake](https://en.wikipedia.org/wiki/Qmake)
+* [Youcompleteme](http://valloric.github.io/YouCompleteMe/)
+* [pkg-config](https://en.wikipedia.org/wiki/Pkg-config)
+* [brew](https://brew.sh/) - package manager for macos
+* [Kristoffer's talk](https://www.youtube.com/watch?v=4ua5aeKKDzU) on package managers
+* [RPM](https://en.wikipedia.org/wiki/RPM_Package_Manager)
+* [Nix](https://en.wikipedia.org/wiki/Nix_package_manager) and [Nixos](https://en.wikipedia.org/wiki/NixOS)
+* [Electric fence](https://en.wikipedia.org/wiki/Electric_Fence)
+* [YAML](https://en.wikipedia.org/wiki/YAML)
+* [Conan](https://www.conan.io)
+
+## Titles ##
+* I was loooking for alternatives
+* We decided to try again
+* The perfect academic solution
+* Usually it's a bash script
+* We know what kind of pain they go through
+* The community won't move
+* We wanted to be hackable
+* When I wrote my own dependency system
+* A beautiful concept you can implement with generators
+* We all hate the syntax of cmake
+* Just an abuse of the system
+* The full devops world has to change
+* We know how to  automate all the parts
+* A mistake by design
+* We are betting on that this is going to help us in the long run
+* We had four build systems
+* One of the reasons we wanted to switch is that it was horrible
+* I remember the gnashing of teeth
+* The pain is bigger than the investment
+* Being very magical
+* The magic eventually becomes a pain point
+* I'm opposed to magic
+* Freedom to shoot yourself in the foot
+* The biggest gun to shoot yourself
+* The domain was available

--- a/content/international/210.md
+++ b/content/international/210.md
@@ -1,0 +1,76 @@
++++
+date = 2017-05-30T05:26:14Z
+draft = false
+title = "Kodsnack 210 - Expose yourself to ideas"
+slug = "210"
+aliases = ["/blog/2017/05/30/210"]
+categories = ["avsnitt"]
+audiofile = "https://traffic.libsyn.com/kodsnack/210.mp3"
+libsynid = "5388831"
+english = true
+audiosize = "21754490"
+audiolength = "45:18"
++++
+
+Recorded at Gothenburg startup hack 2017, a little celebration of being social around coding. Fredrik chats to first Erik Thorelli of the Gothenburg Sketch & design meetup, then Erik Larkö of the Bring your own project Gothenburg group. Topics stretch from what Sketch is and what it can do for you, over group recommendations, to side projects, where to find ideas and how to get over whichever obstacles we put up in our minds to playing with new things.
+
+Thank you [Cloudnet](http://www.cloudnet.se) for sponsoring our [VPS](http://en.wikipedia.org/wiki/Virtual_private_server)!
+
+Comments, questions or tips? We are [@kodsnack](https://www.twitter.com/kodsnack), [@tobiashieta](https://www.twitter.com/tobiashieta), [@iskrig](https://www.twitter.com/iskrig) och [@bjoreman](https://www.twitter.com/bjoreman) on Twitter, have a [page on Facebook](https://www.facebook.com/kodsnack) and can be emailed on [info@kodsnack.se](mailto:info@kodsnack.se) if you want to write something longer. We read everything you send.
+
+If you like Kodsnack we would love a [review in iTunes](http://itunes.apple.com/se/podcast/kodsnack/id561631498?l=en)!
+
+02:19: Sketch & design with Erik Thorelli
+22:01: Bring your own project with Erik Larkö
+
+## Links ##
+* [Gothenburg startup hack](http://www.gbgstartuphack.com/)
+* [The startup panel discussion](https://kodsnack.se/157/)
+* [Erik Thorelli](https://www.linkedin.com/in/erikthorelli/)
+* [Erik Larkö](https://twitter.com/eriklarko)
+* [The Sketch & design meetup](https://www.meetup.com/Sketch-App-Meetup-Goteborg/)
+* [Sketch](https://sketchapp.com/)
+* [Bionote](http://bionote.xyz/)
+* [Moom](https://manytricks.com/moom/)
+* [Invision](https://www.invisionapp.com/)
+* [Airbnb's tool to render React components to Sketch](https://github.com/airbnb/react-sketchapp)
+* [Got UX](https://www.meetup.com/got-ux/)
+* [The React meetup](https://www.meetup.com/ReactJS-Goteborg/)
+* [Dan Abramov](https://twitter.com/dan_abramov)
+* [Bring your own project Gothenburg](https://www.meetup.com/Bring-Your-Own-Project-Gothenburg/)
+* [John Carmack](https://en.wikipedia.org/wiki/John_Carmack)
+* [Gothenburg lounge hackers](https://www.meetup.com/Goteborg-Lounge-Hackers/)
+* [Helen V. Holmes - critique is terrifying](https://medium.com/@helenvholmes/critique-is-terrifying-e2168d017df8)
+* [Purple shopper](https://github.com/eriklarko/purple-shopper) - the purple things buyer
+* [Robopong](https://github.com/eriklarko/robopong)
+* [Purple scout](http://www.purplescout.se/)
+* [Dark web](https://en.wikipedia.org/wiki/Dark_web)
+* [The Docker meetup](https://www.meetup.com/Docker-Goteborg/)
+* [Got.λ](https://www.meetup.com/got-lambda/) - the functional programming group
+* [Papers we love](https://www.meetup.com/Papers-We-Love-Gothenburg/)
+
+## Titles ##
+* Two Eriks
+* Not so cluttered as an Adobe app
+* Visualizing what the heck you're trying to build
+* I spend ten minutes adjusting the battery level
+* DevUX
+* Can I use it for something?
+* Maybe you've never designed anything before
+* Appealing, even for me
+* Faster than fiddling around with CSS
+* It helps reduce waste
+* A caricature of a designer and a developer
+* Asymmetrical pair programming and designing
+* A compiler for design
+* Feels weird, but in a good way
+* Semi-empty Github projects
+* I want my Github page to be cool
+* Why do you want to be John Cleese?
+* Dare to fail
+* Be a good person
+* I don't think I've ever finished a project
+* Where do you get your ideas from? I steal them
+* Expose yourself to ideas
+* The world doesn't need another Pong game, but you need to write a Pong game
+* Developing as a developer

--- a/content/international/227.md
+++ b/content/international/227.md
@@ -1,0 +1,97 @@
++++
+date = 2017-09-26T05:26:14Z
+draft = false
+title = "Kodsnack 227 - Xiki: an idea whose time has come"
+slug = "227"
+aliases = ["/blog/2017/09/26/227"]
+categories = ["avsnitt"]
+audiofile = "https://traffic.libsyn.com/kodsnack/227.mp3"
+libsynid = "5750606"
+english = true
+audiosize = "38031887"
+audiolength = "01:14:56"
++++
+
+Fredrik chats with [Craig Muth](https://github.com/trogdoro), creator of the more than slightly mind-bending [Xiki](http://xiki.org/) about the past, present and future of this weird and wonderful evolution of the command line. Seeing Xiki in action is probably the best way to begin to grasp it, and Craig has created several great videos and screencasts.
+
+We go all the way from Xiki's beginnings as a framework inside of Emacs to its current state as a standalone companion to your normal command line, and its just launched Kickstarter to take the next step and become social by making it super simple to share and find commands. We also look further into the future, entering completely free-form speculation about where things could go both for command lines and user-extendable interfaces. (Yes, Hyper card and Opendoc both come up.)
+
+Don't assume things you want will happen - back things you want to succeed!
+
+Cheer up the autumn: on October 3rd [Suse](https://www.suse.com/) is sponsoring a live pod and after work in Stockholm! 
+
+We'll occupy [Hobo](https://hobo.se/sv/) at Brunkebergstorg 4. Doors open at 17, the pod commences somewhere around 18, and then we talk code, life, the universe, and everything and have some nice drinks for as long as we like.
+
+We hope to see *you* there, and that you bring along a friend or two! The number of seats are limited, so send an email as soon as possible to [livepodd@gmail.com](mailto:livepodd@gmail.com) with your name, company and if you're bringing anyone along.
+
+Thank you [Cloudnet](http://www.cloudnet.se) for sponsoring our [VPS](http://en.wikipedia.org/wiki/Virtual_private_server)!
+
+Comments, questions or tips? We are [@kodsnack](https://www.twitter.com/kodsnack), [@tobiashieta](https://www.twitter.com/tobiashieta), [@iskrig](https://www.twitter.com/iskrig) and [@bjoreman](https://www.twitter.com/bjoreman) on Twitter, have a [page on Facebook](https://www.facebook.com/kodsnack) and can be emailed at [info@kodsnack.se](mailto:info@kodsnack.se) if you want to write longer. We read everything we receive.
+
+If you enjoy Kodsnack we would love a [review in iTunes](http://itunes.apple.com/se/podcast/kodsnack/id561631498?l=en)!
+
+## Links ##
+* [Craig on Github](https://github.com/trogdoro)
+* [Xiki](http://xiki.org/)
+* [The 2014 Xiki Kickstarter](https://www.kickstarter.com/projects/xiki/xiki-the-command-revolution)
+* [The current (2017) Kickstarter](https://www.kickstarter.com/projects/xiki/xikihub-the-social-command-line) - includes the videos we talk about
+* [The older screencasts](http://xiki.org/screencasts/)
+* [Quicksilver](https://qsapp.com/)
+* [Xikihub](http://xiki.com/)
+* [Riverdance](https://en.wikipedia.org/wiki/Riverdance)
+* The talks are also on the [screencasts page](http://xiki.org/screencasts/)
+* [Emacs](https://en.wikipedia.org/wiki/Emacs)
+* [Elisp](https://en.wikipedia.org/wiki/Emacs_Lisp) - Emacs Lisp
+* [Bash](https://en.wikipedia.org/wiki/Bash_%28Unix_shell%29)
+* [Z shell](https://en.wikipedia.org/wiki/Z_shell)
+* [The Medium post - Xiki: one developer’s quest to turbocharge the command line interface](https://medium.freecodecamp.org/xiki-one-developers-quest-to-turbocharge-the-command-line-interface-b68e5345788d)
+* [Made to stick](https://www.amazon.com/Made-Stick-Ideas-Survive-Others/dp/1400064287)
+* [React native](https://facebook.github.io/react-native/)
+* [EJB](https://en.wikipedia.org/wiki/Enterprise_JavaBeans)
+* [CORBA](https://en.wikipedia.org/wiki/Common_Object_Request_Broker_Architecture)
+* [JSON](https://en.wikipedia.org/wiki/JSON)
+* [CSON](https://github.com/bevry/cson)
+* [YAML](https://en.wikipedia.org/wiki/YAML)
+* [AWS](https://en.wikipedia.org/wiki/Amazon_Web_Services) - Amazon web services
+* [Xpath](https://en.wikipedia.org/wiki/XPath)
+* [Fish shell](https://fishshell.com/)
+* [Oh my zsh](http://ohmyz.sh/)
+* [Hyper](https://hyper.is/)
+* [D3](https://d3js.org/)
+* [Ward Cunningham](https://twitter.com/WardCunningham)
+* [Smallest federated wiki](http://wardcunningham.github.io/)
+* [The Xiki tutorial](http://xiki.com/@xiki/tutorial)
+* [Roads and bridges: the unseen labor behind our digital infrastructure](http://www.fordfoundation.org/library/reports-and-studies/roads-and-bridges-the-unseen-labor-behind-our-digital-infrastructure) - the paper Fredrik read
+* [Hypercard](https://en.wikipedia.org/wiki/HyperCard)
+* [Mac LC](https://en.wikipedia.org/wiki/Macintosh_LC) computers
+* [Opendoc](https://en.wikipedia.org/wiki/OpenDoc)
+* [Steve Jobs explaining why he's shutting down Opendoc](https://mikecanex.wordpress.com/2011/06/08/wwdc-1997-video-steve-jobs-handles-a-public-insult/)
+
+## Titles ##
+* The command line is awesome when you know exactly what to type
+* All right, now I get it
+* Lost, but in a really exciting way
+* Make the command line work like a search engine
+* A missing piece in the command line
+* Making all the search results myself
+* It doesn't take that many people
+* Riverdance with the horse and the banana
+* Now I get the one thing, but I don't care
+* An idea whose time has come
+* Hey, that's like a command line
+* Way back in Ohio
+* The power you get when you do remember the commands
+* The germ of Xiki
+* I've never been able to stop working on it
+* Users are so key
+* I could add something here!
+* Hey, this doesn't exist yet!
+* In Ohio working at boring banks
+* This better work!
+* My friend Keith thinks I should move to San Francisco
+* Feeling comfortable in my skin for the first time
+* Escape gets you into more trouble!
+* People will fill in the gaps
+* Do for commands what Github did for code
+* Utterly freeform
+* This neat open thing

--- a/content/international/240.md
+++ b/content/international/240.md
@@ -1,0 +1,65 @@
++++
+date = 2017-12-26T05:26:14Z
+draft = false
+title = "Kodsnack 240 - The persistent fear of being exposed as a fraud"
+slug = "240"
+aliases = ["/blog/2017/12/26/240"]
+categories = ["avsnitt"]
+audiofile = "https://traffic.libsyn.com/kodsnack/240.mp3"
+libsynid = "6088635"
+english = true
+audiosize = "40166208"
+audiolength = "01:23:35"
++++
+
+Tobias, Amanda and Fredrik discuss [impostor syndrome](https://en.wikipedia.org/wiki/Impostor_syndrome) with Wendi Dunford, [LCSW](https://www.humanservicesedu.org/lcswvspsychologist.html#context/api/listings/prefilter). Impostor syndrome affects all three of us and so many others, so we thought it was time to talk to someone who really knows the subject. Our discussion covers defining impostor syndrome, how we all experience it, various types of impostor syndrome and things both we and others can do to combat it.
+
+Spoiler: the secret to impostor syndrome is your ego!
+
+Five types or aspects of impostor syndrome:
+
+* The perfectionist - I'm never good enough
+* The superwoman or superman - workaholics to compensate
+* The natural genius - I freak out if I can't get it right the first time
+* The individualist - I go at it alone, and I don't ask for help
+* The expert - I somehow tricked everybody, it was a glitch
+
+If you have tips on how you've dealt with impostor syndrome, or have found a great resource on the subject, please let us know!
+
+Thank you [Cloudnet](http://www.cloudnet.se) for sponsoring our [VPS](http://en.wikipedia.org/wiki/Virtual_private_server)!
+
+Comments, questions or tips? We are [@kodsnack](https://www.twitter.com/kodsnack), [@tobiashieta](https://www.twitter.com/tobiashieta), [@iskrig](https://www.twitter.com/iskrig) and [@bjoreman](https://www.twitter.com/bjoreman) on Twitter, have a [page on Facebook](https://www.facebook.com/kodsnack) and can be emailed at [info@kodsnack.se](mailto:info@kodsnack.se) if you want to write longer. We read everything we receive.
+
+If you enjoy Kodsnack we would love a [review in iTunes](http://itunes.apple.com/se/podcast/kodsnack/id561631498?l=en)!
+
+## Links ##
+* [Impostor syndrome](https://en.wikipedia.org/wiki/Impostor_syndrome)
+* [Wendi Dunford](https://twitter.com/therapythursdys)
+* [Code review](https://en.wikipedia.org/wiki/Code_review)
+* [360-degree feedback](https://en.wikipedia.org/wiki/360-degree_feedback) - the review system in use by Plex (discussed in [episode 233](https://kodsnack.se/233/))
+* [Curling parenting](https://en.wikipedia.org/wiki/Helicopter_parent)
+* [Jantelagen](https://en.wikipedia.org/wiki/Law_of_Jante) - "The law of Jante"
+* [The morning stream](http://frogpants.com/tms)
+* [Therapy Thursdays](https://therapythursdays.com/)
+* [Advent of code](http://adventofcode.com/)
+* Share your solutions in [Kodsnack's Github repo](https://github.com/kodsnack/advent_of_code_2017/)!
+
+## Titles ##
+* You're never enough
+* You're a real psychologist, right?
+* The feeling that you don't belong
+* An inability to internalize your accomplishments
+* The persistent fear of being exposed as a fraud
+* It was just luck
+* Oops, I just won!
+* More eyes makes it more stressful
+* Throw someone off, confidence-wise
+* I don't deserve this anyway
+* That's not a reason to not take a job
+* The story you tell yourself
+* I don't have to perform for friends
+* The work of children is to play
+* I don't have to buy into it
+* Try the compliment trick
+* Being wrong doesn't make you fake
+* Reveal yourself as the fraud you are

--- a/content/international/241.md
+++ b/content/international/241.md
@@ -1,0 +1,84 @@
++++
+date = 2018-01-02T05:26:14Z
+draft = false
+title = "Kodsnack 241 - Looking for the killer apps in VR"
+slug = "241"
+aliases = ["/blog/2018/01/02/241"]
+categories = ["avsnitt"]
+audiofile = "https://traffic.libsyn.com/kodsnack/241.mp3"
+libsynid = "6104756"
+english = true
+audiosize = "16033975"
+audiolength = "33:19"
++++
+
+Fredrik discusses VR with [Noah Falstein](https://en.wikipedia.org/wiki/Noah_Falstein) of [the Inspiracy](http://www.theinspiracy.com/) (and previously companies such as Google and Lucasfilm games). We talk about where VR is today, which platforms are good today and what might happen going forward. VR might be on the verge of a big breakthrough but there is still a lot left to be discovered, from ways of controlling experiences to entire new genres.
+
+Recorded on stage at [Øredev 2017](http://oredev.org/2017).
+
+Thank you [Cloudnet](http://www.cloudnet.se) for sponsoring our [VPS](http://en.wikipedia.org/wiki/Virtual_private_server)!
+
+Comments, questions or tips? We are [@kodsnack](https://www.twitter.com/kodsnack), [@tobiashieta](https://www.twitter.com/tobiashieta), [@iskrig](https://www.twitter.com/iskrig) and [@bjoreman](https://www.twitter.com/bjoreman) on Twitter, have a [page on Facebook](https://www.facebook.com/kodsnack) and can be emailed at [info@kodsnack.se](mailto:info@kodsnack.se) if you want to write longer. We read everything we receive.
+
+If you enjoy Kodsnack we would love a [review in iTunes](http://itunes.apple.com/se/podcast/kodsnack/id561631498?l=en)!
+
+## Links ##
+* [Noah Falstein](https://en.wikipedia.org/wiki/Noah_Falstein)
+* [Lucasfilm games](https://en.wikipedia.org/wiki/LucasArts)
+* [Indiana Jones and the last crusade](https://en.wikipedia.org/wiki/Indiana_Jones_and_the_Last_Crusade:_The_Graphic_Adventure)
+* [Noah's keynote](https://vimeo.com/241863709) - "The real, the virtual, and the cortex"
+* [Noah's second presentation](https://vimeo.com/242775763) - Lucasfilm games and the rise of Lucasarts
+* [Habitat](https://en.wikipedia.org/wiki/Habitat_%28video_game%29)
+* [The Habitat promotional video](https://www.youtube.com/watch?v=VVpulhO3jyc)
+* [Club Caribe](http://vzn.eddcoates.com/clubcaribe/)
+* [Quantum link](https://en.wikipedia.org/wiki/Quantum_Link)
+* [The QWERTY keyboard](https://en.wikipedia.org/wiki/QWERTY)
+* [The OS X dock](https://en.wikipedia.org/wiki/Dock_%28macOS%29)
+* [Google Spotlight stories](https://atap.google.com/spotlight-stories/)
+* [Pearl](https://www.youtube.com/watch?v=WqCH4DNQBUA&feature=youtu.be)
+* [Special delivery](http://www.aardman.com/work/special-delivery/) - by Aardman animation
+* [The Simpsons VR episode](http://www.simpsonscardboard.com/)
+* [A nice (360) flight over Pyonyang](https://www.youtube.com/watch?v=S44YKdc3G3U&t=430s)
+* [James Cameron's Avatar sequels](https://en.wikipedia.org/wiki/Avatar_%282009_film%29#Sequels)
+* [Games for health](https://en.wikipedia.org/wiki/Games_for_Health)
+* [40 predictions for VR/AR through 2025](https://www.youtube.com/watch?v=iUN2BoZU8xI&t=1697s)
+* [Dataglove](https://en.wikipedia.org/wiki/Wired_glove)
+* [Jaron Lanier](https://en.wikipedia.org/wiki/Jaron_Lanier)
+* [Apple Newton](https://en.wikipedia.org/wiki/Apple_Newton)
+* [Polybius](https://en.wikipedia.org/wiki/Polybius_%282017_video_game%29)
+* [Jeff Minter](https://en.wikipedia.org/wiki/Jeff_Minter)
+* [Virtual virtual reality](https://www.youtube.com/watch?v=Sb1efNYhkGI)
+* [Portal](https://en.wikipedia.org/wiki/Portal_%28video_game%29)
+* [The lost bear](https://www.thelostbeargame.com/)
+* [Steve Meretzky](https://en.wikipedia.org/wiki/Steve_Meretzky)
+* [Planetfall](https://en.wikipedia.org/wiki/Planetfall)
+* [The Sims](https://en.wikipedia.org/wiki/The_Sims)
+* [Doom](https://en.wikipedia.org/wiki/Doom_%281993_video_game%29)
+* [Castle Wolfenstein](https://en.wikipedia.org/wiki/Castle_Wolfenstein)
+* [Katamari damacy](https://en.wikipedia.org/wiki/Katamari_Damacy)
+* [Memory palaces](https://en.wikipedia.org/wiki/Method_of_loci)
+* [Alphago](https://en.wikipedia.org/wiki/AlphaGo) and [Alphago zero](https://en.wikipedia.org/wiki/AlphaGo_Zero)
+* [The holodeck](https://en.wikipedia.org/wiki/Holodeck)
+* [Dream park](https://en.wikipedia.org/wiki/Dream_Park), by Larry Niven and Steven Barnes
+* [Ready player one](https://en.wikipedia.org/wiki/Ready_Player_One)
+* [Black mirror](https://en.wikipedia.org/wiki/Black_Mirror)
+
+## Titles ##
+* Nobdy had ever experienced that
+* I become a character in the computer?
+* A realtime, constant back and forth
+* A version that doesn't allow you to do most of the fun stuff
+* It demos well
+* Still looking for the killer apps in VR
+* The grammar of VR storytelling
+* The Spielberg or Lucas of VR
+* An "of course" moment
+* Something came along and ate the flower
+* I'm tired of watching things eat eachother
+* The Pixar movies of 2020
+* Hard plastic is actually preferable
+* As scary as they need to be
+* A robot named Floyd
+* We were discovering entirely new genres
+* Put that house into VR
+* Page number 27: things you find in a kitchen

--- a/content/international/245.md
+++ b/content/international/245.md
@@ -1,0 +1,88 @@
++++
+date = 2018-01-30T05:26:14Z
+draft = false
+title = "Kodsnack 245 - An empathetic thing, with Steve Klabnik"
+slug = "245"
+aliases = ["/blog/2018/01/30/245"]
+categories = ["avsnitt"]
+audiofile = "https://traffic.libsyn.com/kodsnack/245.mp3"
+libsynid = "6197017"
+english = true
+audiosize = "28519052"
+audiolength = "59:06"
++++
+
+Fredrik chats with [Steve Klabnik](https://www.steveklabnik.com/) about [Rust](https://www.rust-lang.org/), why the lucky stiff, [Closure](http://words.steveklabnik.com/the-closure-companion) and Webassembly.
+
+What does Steve do, how is Rust coming along and how does the process work?
+
+Who was why the lucky stiff and why does his publication later named Closure matter to people?
+
+Finally: Webassembly, making the web good for applications in general and why Steve thinks it will be the biggest thing since Javascript was added to browsers.
+
+Recorded on stage at [Øredev 2017](http://oredev.org/2017).
+
+Thank you [Cloudnet](http://www.cloudnet.se) for sponsoring our [VPS](http://en.wikipedia.org/wiki/Virtual_private_server)!
+
+Comments, questions or tips? We are [@kodsnack](https://www.twitter.com/kodsnack), [@tobiashieta](https://www.twitter.com/tobiashieta), [@iskrig](https://www.twitter.com/iskrig) and [@bjoreman](https://www.twitter.com/bjoreman) on Twitter, have a [page on Facebook](https://www.facebook.com/kodsnack) and can be emailed at [info@kodsnack.se](mailto:info@kodsnack.se) if you want to write longer. We read everything we receive.
+
+If you enjoy Kodsnack we would love a [review in iTunes](http://itunes.apple.com/se/podcast/kodsnack/id561631498?l=en)!
+
+## Links ##
+* [Libsyn](https://www.libsyn.com/) - one of the "classic" podcast hosting services
+* [Steve Klabnik](https://www.steveklabnik.com/) and [on Twitter](https://twitter.com/steveklabnik)
+* [Mozilla](https://www.mozilla.org/) - where Steve works
+* [Rust](https://www.rust-lang.org/)
+* [Ruby on rails](https://en.wikipedia.org/wiki/Ruby_on_Rails)
+* [Mac OS 9](https://en.wikipedia.org/wiki/Mac_OS_9)
+* [Øredev](http://oredev.org/)
+* [Jon Moore](https://twitter.com/jon_moore) gave a [talk on hypermedia in 2010](http://oredev.org/oredev2010/2010/sessions/hypermedia-apis.html)
+* [The "No balloons" sign](https://twitter.com/steveklabnik/status/927526410180268032)
+* [Epics or epochs in Rust](https://github.com/rust-lang/rfcs/blob/master/text/2052-epochs.md)
+* [The Rust programming language](https://doc.rust-lang.org/book/)
+* [No starch press](https://nostarch.com/)
+* [? in Rust](https://m4rw3r.github.io/rust-questionmark-operator)
+* [crates.io](https://crates.io/) - the Rust package registry
+* [Cargo](https://doc.rust-lang.org/cargo/) - the Rust package manager
+* [Ashley Williams](https://github.com/ashleygwilliams)
+* [intermezzOS](https://github.com/intermezzOS) - the operating system Steve and Ashley are writing in Rust
+* [Redox](https://redox-os.org/)
+* [LLVM](https://en.wikipedia.org/wiki/LLVM)
+* [Servo](https://en.wikipedia.org/wiki/Servo_%28layout_engine%29)
+* [Closure](http://words.steveklabnik.com/the-closure-companion) - the book
+* [why the lucky stiff](https://en.wikipedia.org/wiki/Why_the_lucky_stiff)
+* [why's (poignant) guie to Ruby](http://poignant.guide/)
+* [Hackety hack](https://github.com/hacketyhack) - and [on Wikipedia](https://en.wikipedia.org/wiki/Hackety_Hack)
+* [Shoes](https://en.wikipedia.org/wiki/Shoes_%28GUI_toolkit%29)
+* [Steve's Madison Ruby talk about Closure](https://www.youtube.com/watch?v=MaWHVceDbFo)
+* [The blog post, as linked above](http://words.steveklabnik.com/the-closure-companion)
+* [Keving Brock](http://www.brockoleur.com/)
+* [Imogen Heap and her gloves](https://www.youtube.com/watch?v=7oeEQhOmGpg)
+* [Webassembly](http://webassembly.org/)
+* [Nacl](https://developer.chrome.com/native-client)
+* [Dart](https://www.dartlang.org/)
+* [asm.js](http://asmjs.org/)
+* [Pnacl](https://developer.chrome.com/native-client/nacl-and-pnacl)
+* [LLVM-IR](https://en.wikipedia.org/wiki/LLVM#Intermediate_representation)
+* [Ethereum](https://en.wikipedia.org/wiki/Ethereum)
+* [Roku](https://en.wikipedia.org/wiki/Roku)'
+* [The WebUSB specification](https://wicg.github.io/webusb/)
+* [The birth and death of Javascript](https://www.destroyallsoftware.com/talks/the-birth-and-death-of-javascript)
+* [Dan Callahan compiling Dosbox](https://www.youtube.com/watch?v=bac0dGQbUto)
+* [Dosbox](http://www.dosbox.com/)
+* [Netscape 1.0](https://www.youtube.com/watch?v=Ojmng198Ni0)
+
+## Titles ##
+* Hi, I'm Steve
+* Straight to Linux
+* Building a commons
+* People over companies
+* Could be rich by being miserable
+* An empathetic thing
+* Words that weren't going out of date
+* Safety, performance and ergonomics
+* People don't build bridges on sand
+* My job is all English, not code
+* Picking up someone else's life work
+* None of this makes any sense, Steve
+* Compile Rust in Rust in the browser

--- a/content/international/258.md
+++ b/content/international/258.md
@@ -1,0 +1,49 @@
++++
+date = 2018-05-01T05:26:12Z
+draft = false
+title = "Kodsnack 258 - Object-oriented assembly with Marco Ceccione"
+slug = "258"
+aliases = ["/blog/2018/05/01/258"]
+categories = ["avsnitt"]
+audiofile = "https://traffic.libsyn.com/kodsnack/258.mp3"
+libsynid = "6534554"
+english = true
+audiosize = "16918823"
+audiolength = "35:07"
++++
+
+Recorded at [Øredev 2017](http://oredev.org/2017), Fredrik talks to [Marco Ceccione](https://twitter.com/sklivvz) about the ZX Spectrum, positive hacking (the only kind there is!), the benefits of getting closer to the metal and finally balancing coding and management.
+
+Marco is an engineering manager at [Toptal](https://www.toptal.com/). Before that, he worked at Stack overflow, where, among other things, he wrote object-oriented assembly to solve real-wold problems on a huge scale. Yes, that's a real thing, discussion and links explains it all.
+
+Thank you [Cloudnet](http://www.cloudnet.se) for sponsoring our [VPS](http://en.wikipedia.org/wiki/Virtual_private_server)!
+
+Comments, questions or tips? We are [@kodsnack](https://www.twitter.com/kodsnack), [@tobiashieta](https://www.twitter.com/tobiashieta), [@iskrig](https://www.twitter.com/iskrig) and [@bjoreman](https://www.twitter.com/bjoreman) on Twitter, have a [page on Facebook](https://www.facebook.com/kodsnack) and can be emailed at [info@kodsnack.se](mailto:info@kodsnack.se) if you want to write longer. We read everything we receive.
+
+If you enjoy Kodsnack we would love a [review in iTunes](http://itunes.apple.com/se/podcast/kodsnack/id561631498?l=en)!
+
+## Links ##
+* [Marco Ceccioni](https://sklivvz.com/)
+* [Marco's Øredev presentation about the ZX Spectrum](https://vimeo.com/242060846)
+* [ZX Spectrum](https://en.wikipedia.org/wiki/ZX_Spectrum)
+* [BIOS](https://en.wikipedia.org/wiki/BIOS)
+* [EFI](https://en.wikipedia.org/wiki/Unified_Extensible_Firmware_Interface)
+* [Right to repair](https://www.bleepingcomputer.com/news/government/eu-prepares-right-to-repair-legislation-to-fight-short-product-lifespans/)
+* [Arduino](https://en.wikipedia.org/wiki/Arduino)
+* [MSIL](https://en.wikipedia.org/wiki/Common_Intermediate_Language)
+* [Russell's barber](https://en.wikipedia.org/wiki/Barber_paradox)
+* [Toptal](https://www.toptal.com/) - where Marco works
+* [Grafana](https://grafana.com/)
+* [Doctor Dobb's articles on writing Quake](http://www.drdobbs.com/ramblings-in-real-time/184410037)
+
+## Titles ##
+* I was presenting this very very old computer
+* Take the train and go to Milan
+* Disassembling code by hand
+* A very hands-on period
+* Supremely hackable
+* First repair it, then write some software for it
+* Object-oriented assembly
+* Ultimately, you have to code for the machine
+* Hacking is always positive
+* If they break, we don't fix them

--- a/content/international/34.md
+++ b/content/international/34.md
@@ -1,0 +1,37 @@
++++
+date = 2013-11-29T18:58:39Z
+draft = false
+title = "Kodsnack 34 - Intervju med Jono Bacon"
+slug = "34"
+aliases = ["/blog/2013/11/29/kodsnack-34-intervju-med-jono-bacon"]
+categories = ["avsnitt"]
+audiofile = "https://traffic.libsyn.com/kodsnack/jono.mp3"
+english = true
+audiosize = "22070076"
+audiolength = "43:50"
++++
+
+{{% figure src="/img/jono.jpg" title="Jono Bacon" %}}
+
+[Internetdagarna](http://internetdagarna.se/) är över! Vi lämnade Stockholm Waterfront med ett par intervjuer, reflektioner och en hel del idéer och uppslag för vad vi vill göra med podcasten framöver.
+
+Först ut är vår intervju med [Jono Bacon](http://www.jonobacon.org/). Jono är Community Manager på [Canonical](http://www.canonical.com/), företaget som ligger bakom Linux-distributionen [Ubuntu](http://www.ubuntu.com/). Han var på Internetdagarna för att hålla en keynote med teman Community, så våra frågor började där. Han är dock även programmerare, musiker och en allmänt trevlig snubbe, så vi hinner avverka allt möjligt från hemmakontor till mobilprogrammering.
+
+Jono har även sin egen [podcast](http://www.badvoltage.org/) som vi rekommenderar till alla som är intresserade av öppen källkod eller bara vill höra mer av Jono. Vi låter det här citatet från vår intervju tjäna som ett smakprov eller varning!
+
+> "Some people are just assholes. Some people are just grade-A, copper-bottom, 24 carat gold assholes out there!"
+
+## Länkar ##
+
+* Jonos hemsida: [jonobacon.org](http://www.jonobacon.org/)
+* Jono på twitter: [@jonobacon](https://twitter.com/jonobacon)
+* [Severed Fifth](https://www.facebook.com/severedfifth)
+* [Art of Community](http://www.artofcommunityonline.org/)
+* [Bad Voltage](http://www.badvoltage.org/)
+* [Ubuntu Touch SDK Beta](http://insights.ubuntu.com/news/ubuntu-touch-sdk-beta/)
+* [iRaccoonShow](http://www.iraccoonshow.tk/)
+* [PhoneGap](http://phonegap.com/)
+* [Ubuntu JuJu](https://juju.ubuntu.com/)
+* [Gustavo Niemeyer - Ubuntu Touch och Go](https://plus.google.com/+GustavoNiemeyer/posts/54Q8NwbRwng)
+* [Bad Voltage pratar om PS4 och XBone](http://www.badvoltage.org/2013/11/21/1x03/)
+

--- a/content/international/78.md
+++ b/content/international/78.md
@@ -1,0 +1,57 @@
++++
+date = 2014-11-25T10:26:14Z
+draft = false
+title = "Kodsnack 78 - Stirring the pot is necessary"
+slug = "78"
+aliases = ["/blog/2014/11/25/78"]
+categories = ["avsnitt"]
+audiofile = "https://traffic.libsyn.com/kodsnack/78.mp3"
+libsynid = "3199763"
+english = true
+audiosize = "40647124"
+audiolength = "48:21"
++++
+
+We chat with [Fred George](https://twitter.com/fgeorge52), handgrenade of software development, live on stage during [Øredev](http://www.oredev.org) 2014. Topics include choosing clients, getting out before you start breaking things, the right ways of changing, the value of methodologies, remote work, gams, languages and more.
+
+This recording exists as good as it is thanks to [Stephen Chin](http://steveonjava.com/) of [nighthacking.com](http://nighthacking.com/) for providing and masterfully wrangling all the necessary technology.
+
+You can [discuss this episode](http://techworld.idg.se/2.2524/1.595938/) at Techworld!
+
+## Links ##
+* [Mail Online](http://www.dailymail.co.uk/home/index.html)
+* [Node](http://nodejs.org)
+* [Lean thinking](http://books.simonandschuster.com/Lean-Thinking/James-P-Womack/9780743249270)
+* [Scrum master](http://en.wikipedia.org/wiki/Scrum_%28software_development%29#Scrum_Master)
+* [Agile coach](http://www.agileconnection.com/article/role-agile-coach)
+* [Clojure](http://clojure.org)
+* [Fad diet](http://en.wikipedia.org/wiki/Food_faddism)
+* [Thoughtworks](http://en.wikipedia.org/wiki/ThoughtWorks)
+* [Java Spring framework](http://en.wikipedia.org/wiki/Spring_Framework)
+* [Outpace](http://www.outpace.com)
+* [Pong](http://en.wikipedia.org/wiki/Pong)
+* [Dreamhack](http://en.wikipedia.org/wiki/Dreamhack)
+* [Starcraft](http://en.wikipedia.org/wiki/StarCraft)
+* [Skyrim](http://en.wikipedia.org/wiki/The_Elder_Scrolls_V:_Skyrim)
+* [The law of large numbers](http://en.wikipedia.org/wiki/Law_of_large_numbers)
+* [Metal](https://developer.apple.com/metal/)
+* [Swift](https://developer.apple.com/swift/)
+* [Palo Alto Swift user group](http://www.meetup.com/swift-language/)
+* [Øredev session on Swift](http://oredev.org/2014/sessions/swift-swiftly)
+* [Elixir](http://elixir-lang.org)
+* [Dave Thomas](http://en.wikipedia.org/wiki/Dave_Thomas_%28programmer%29)
+* [Erlang virtual machine](https://erlangcentral.org/tag/beam/)
+* [Micro services](http://martinfowler.com/articles/microservices.html)
+* [Key value store](http://db-engines.com/en/article/Key-value+Stores)
+* [Database transaction](http://en.wikipedia.org/wiki/Database_transaction)
+* [Forward internet group](http://www.forward.co.uk)
+* Fred Georges' sessions at Øredev: [Enabling emergent technologies](http://oredev.org/2014/sessions/enabling-emergent-technologies) and [Microservices: lessons from 3 companies](http://oredev.org/2014/sessions/microservices-lessons-from-3-companies)
+* [KPI](http://management.about.com/cs/generalmanagement/a/keyperfindic.htm) - Key performance indicators
+* [Waterfall model of software development](http://en.wikipedia.org/wiki/Waterfall_model)
+* [COBOL](http://en.wikipedia.org/wiki/COBOL)
+* [C-level executives](http://en.wikipedia.org/wiki/Corporate_title)
+* [Richard Gabriel](http://en.wikipedia.org/wiki/Richard_P._Gabriel)
+* [Lucid Emacs](http://en.wikipedia.org/wiki/XEmacs)
+* [Worse is better](http://en.wikipedia.org/wiki/Worse_is_better) - paper by Richard Gabriel
+* [Myspace](http://en.wikipedia.org/wiki/Myspace)
+* [Valve organizational structure](http://en.wikipedia.org/wiki/Valve_Corporation#Organizational_structure)

--- a/content/international/80.md
+++ b/content/international/80.md
@@ -1,0 +1,121 @@
++++
+date = 2014-12-09T10:26:14Z
+draft = false
+title = "Kodsnack 80 - Where numbers don't have to be special anymore"
+slug = "80"
+aliases = ["/blog/2014/12/9/80"]
+categories = ["avsnitt"]
+audiofile = "https://traffic.libsyn.com/kodsnack/Stefan_Karpinski.mp3"
+libsynid = "3224860"
+english = true
+audiosize = "20304139"
+audiolength = "42:58"
++++
+
+We chat with [Stefan Karpinski](http://karpinski.org/), creator of the [Julia programming language](http://julialang.org/), live on stage during [Øredev](http://www.oredev.org) 2014. Topics include deciding to build a new language, the interesting unsolved problems of numerical computing, concurrency solutions, developing with and on LLVM, handling deprecation nicely, things (possibly) in the future for Julia and why Swift is exciting for Julia and other languages.
+
+This recording exists as good as it is thanks to [Stephen Chin](http://steveonjava.com/) of [nighthacking.com](http://nighthacking.com/) for providing and masterfully wrangling all the necessary technology.
+
+There is a minute and a half of worse audio quality just after the nine minute mark, where microphone problems forced us to fill in with audio from our backup microphone.
+
+Comments, thoughts or suggestions? [Discuss this episode](http://techworld.idg.se/2.2524/1.599981/) at Techworld!
+
+## Links ##
+* [Stefan Karpinski](http://karpinski.org/)
+* [Julia programming language](http://julialang.org/)
+* [Scientific computing](http://en.wikipedia.org/wiki/Computational_science)
+* [Viral Shah](https://twitter.com/viral_b_shah)
+* [Jeff Bezanson](https://twitter.com/jeffbezanson)
+* [MATLAB](http://en.wikipedia.org/wiki/MATLAB)
+* [R](http://en.wikipedia.org/wiki/R_%28programming_language%29) programming language
+* [Python](http://en.wikipedia.org/wiki/Python_%28programming_language%29)
+* [C extension](https://docs.python.org/2/extending/extending.html)
+* [Goldilocks](http://en.wikipedia.org/wiki/The_Story_of_the_Three_Bears)
+* [Goldilocks principle](http://en.wikipedia.org/wiki/Goldilocks_principle)
+* [Dylan](http://en.wikipedia.org/wiki/Dylan_%28programming_language%29)
+* [Garbage collection](http://en.wikipedia.org/wiki/Garbage_collection_%28computer_science%29)
+* [Unboxed data](http://en.wikipedia.org/wiki/Object_type_%28object-oriented_programming%29#Unboxing)
+* [Complex number](http://en.wikipedia.org/wiki/Complex_number)
+* [Julia Webstack](http://juliawebstack.org/)
+* [Numerical computing](http://en.wikipedia.org/wiki/Numerical_analysis)
+* [Concurrency](http://en.wikipedia.org/wiki/Concurrency_%28computer_science%29)
+* [Distributed computing](http://en.wikipedia.org/wiki/Distributed_computing)
+* [Threading](http://en.wikipedia.org/wiki/Thread_%28computing%29)
+* [Julia on Github](https://github.com/JuliaLang/julia)
+* [Transactional memory](http://en.wikipedia.org/wiki/Transactional_memory)
+* [Goroutine](https://gobyexample.com/goroutines)
+* [Coroutine](http://en.wikipedia.org/wiki/Coroutine)
+* [Channel](http://en.wikipedia.org/wiki/Channel_%28programming%29)
+* [I/O](http://en.wikipedia.org/wiki/Input/output)
+* [LLVM](http://llvm.org/)
+* [IFDEF](http://en.wikipedia.org/wiki/C_preprocessor#Conditional_compilation)
+* [JIT](http://en.wikipedia.org/wiki/Just-in-time_compilation)  - just-in-time (compilation, in this case)
+* [Shared library](http://en.wikipedia.org/wiki/Library_%28computing%29#Shared_libraries)
+* [libclang](http://clang.llvm.org/doxygen/group__CINDEX.html) - C Interface to Clang
+* [Template instantiation](https://gcc.gnu.org/onlinedocs/gcc/Template-Instantiation.html)
+* [Quake2.jl](https://github.com/jayschwa/Quake2.jl)
+* [Go](http://golang.org/)
+* [Hacker school](https://www.hackerschool.com/)
+* [Matrix multiplication](http://en.wikipedia.org/wiki/Matrix_multiplication)
+* [Vectorization](http://en.wikipedia.org/wiki/Vectorization)
+* [Generational incremental garbage collection](http://stackoverflow.com/questions/5092134/whats-the-difference-between-generational-and-incremental-garbage-collection/5092380#5092380)
+* [SNOBOL](http://en.wikipedia.org/wiki/SNOBOL)
+* [SPITBOL](http://en.wikipedia.org/wiki/SPITBOL_compiler)
+* [Icon](http://en.wikipedia.org/wiki/Icon_%28programming_language%29)
+* [Perl 4](http://en.wikipedia.org/wiki/Perl#Early_versions)
+* [C99 standard](http://en.wikipedia.org/wiki/C99)
+* [Immutable composite types](http://julia.readthedocs.org/en/latest/manual/types/#immutable-composite-types)
+* [Multiple dispatch](http://en.wikipedia.org/wiki/Multiple_dispatch)
+* [Monkey patch](http://en.wikipedia.org/wiki/Monkey_patch)
+* [radd](http://stackoverflow.com/questions/5082190/help-with-add)-trick in Python
+* [Common Lisp](http://en.wikipedia.org/wiki/Common_Lisp)
+* [CLOS](http://en.wikipedia.org/wiki/Common_Lisp_Object_System) - Common Lisp object system
+* [Polymorphism](http://en.wikipedia.org/wiki/Polymorphism_%28computer_science%29)
+* [Self](http://en.wikipedia.org/wiki/Self_%28programming_language%29)
+* [BLAS](http://docs.julialang.org/en/release-0.1/stdlib/blas/)  - Basic linear algebra subroutines
+* [Fast fourier transform](http://en.wikipedia.org/wiki/Fast_Fourier_transform)
+* [Gofix](http://blog.golang.org/introducing-gofix)
+* [Tracing](http://en.wikipedia.org/wiki/Tracing_%28software%29)
+* [Static compilation](http://en.wikipedia.org/wiki/Static_build)
+* [MIT](http://en.wikipedia.org/wiki/Massachusetts_Institute_of_Technology)  - Massachusetts institute of technology
+* [Courses taught using Julia](http://julialang.org/teaching/)
+* [Function pointer](http://en.wikipedia.org/wiki/Function_pointer)
+* [Scipy](http://www.scipy.org/)
+* [Steven Johnson](http://math.mit.edu/~stevenj/)
+* [FFTW](http://www.fftw.org/)
+* [Pycall package for Julia](https://github.com/stevengj/PyCall.jl)
+* [Call stack](http://en.wikipedia.org/wiki/Call_stack)
+* [GDB](http://www.gnu.org/software/gdb/)
+* [LLDB](http://lldb.llvm.org/)
+* [ABI](http://en.wikipedia.org/wiki/Application_binary_interface)  - application binary interface
+* [Clang](http://clang.llvm.org/)
+* [Rust programming language](http://www.rust-lang.org/)
+* [Swift](https://developer.apple.com/swift/)
+* [Chris Lattner](http://nondot.org/sabre/) - creator of LLVM and Swift
+* [WebKit FTL JIT](https://www.webkit.org/blog/3362/introducing-the-webkit-ftl-jit/) - compiles Javascript using LLVM
+* [Shadow stack](http://llvm.org/docs/GarbageCollection.html#about-the-shadow-stack)
+* [‎Dynamic stack frame deoptimization](http://www.cs.ucsb.edu/~urs/oocsb/papers/pldi92.pdf)
+* [MATLAB matrix concatenation syntax](http://www.tutorialspoint.com/matlab/matlab_matrix_concatenation.htm)
+
+## Titles ##
+* Some of the interesting tradeoffs
+* Bridge that gap between high-level and low-level
+* A huge pointer graph of some kind
+* It's good to have a focus, initially
+* The point where we're pushing things
+* The classic tradition of a ton of IFDEFs
+* This brings us back to garbage collection
+* Specializing for numerical work
+* Where numbers don't have to be special anymore
+* (The question is:) How useful is that generalization?
+* You don't necessarily know what code you're going to need in advance
+* Trading off memory for performance
+* Really doing the deprecation process
+* A situation where normally you'd JIT something
+* You might end up in a slow case
+* You can always just fall back on an interpreter
+* A partially compiled interpreter
+* Nobody needs to know that it was written in Julia
+* A really capable C library
+* As easy as walking a linked pointer list
+* I'm really glad someone else implemented it

--- a/content/international/82.md
+++ b/content/international/82.md
@@ -1,0 +1,142 @@
++++
+date = 2014-12-23T10:26:14Z
+draft = false
+title = "Kodsnack 82 - It's very difficult to make a joke in this space"
+slug = "82"
+aliases = ["/blog/2014/12/23/82"]
+categories = ["avsnitt"]
+audiofile = "https://traffic.libsyn.com/kodsnack/James_Mickens.mp3"
+libsynid = "3242941"
+english = true
+audiosize = "63465620"
+audiolength = "01:06:52"
++++
+
+We chat with [James Mickens](http://research.microsoft.com/en-us/people/mickens/), researcher and most likely funniest man at Microsoft, live on stage during [Øredev](http://www.oredev.org) 2014. Topics include C development, the purity of incrementation, death by specifications, scandinavian death metal and its font choices and also British football, distributed systems and the problems you encounter dealing with them. The downsides of being stuck alone in a set of universes is that Stack overflow can't help you. And how should we fix the Javascript and web browser technology world?
+
+Comments on the internet? No.
+
+This recording exists as good as it is thanks to [Stephen Chin](http://steveonjava.com/) of [nighthacking.com](http://nighthacking.com/) for providing and masterfully wrangling all the necessary technology.
+
+Comments, thoughts or suggestions? [Discuss this episode](http://techworld.idg.se/2.2524/1.602423/) at Techworld!
+
+## Links ##
+* [Freedom fries](http://en.wikipedia.org/wiki/Freedom_fries)
+* [Microsoft research](http://research.microsoft.com/en-us/)
+* [Distributed systems](http://en.wikipedia.org/wiki/Distributed_computing)
+* [James' talk at Øredev 2014](http://oredev.org/2014/sessions/life-is-terrible-lets-talk-about-the-web)
+* [Handling the zombie apocalypse](http://research.microsoft.com/en-us/people/mickens/thenightwatch.pdf) - James' article "The night watch"
+* [James' talk at Monitorama 2014](http://vimeo.com/95066828)
+* [Satya Nadella](http://en.wikipedia.org/wiki/Satya_Nadella) - CEO of Microsoft
+* [Nuclear proliferation](http://en.wikipedia.org/wiki/Nuclear_proliferation)
+* [Segfault](http://en.wikipedia.org/wiki/Segmentation_fault)
+* [Logical shift](http://en.wikipedia.org/wiki/Logical_shift)
+* [Logical AND](http://en.wikipedia.org/wiki/Logical_conjunction)
+* [Malmö](http://en.wikipedia.org/wiki/Malm%C3%B6)
+* [Logical OR](http://en.wikipedia.org/wiki/Logical_disjunction)
+* [W3C](http://en.wikipedia.org/wiki/World_Wide_Web_Consortium) - World wide web consortium
+* [Web components](http://en.wikipedia.org/wiki/Web_Components)
+* [Web components templates](http://webcomponents.org/articles/introduction-to-template-element/)
+* [Gorgoroth](http://en.wikipedia.org/wiki/Gorgoroth)
+* [Fibonacci](http://en.wikipedia.org/wiki/Fibonacci_number)
+* [Factorial](http://en.wikipedia.org/wiki/Factorial)
+* [Fizz buzz](http://en.wikipedia.org/wiki/Fizz_buzz)
+* [Sepultura](http://en.wikipedia.org/wiki/Sepultura)
+* [King diamond](http://en.wikipedia.org/wiki/King_Diamond_%28band%29)
+* [British steel](http://en.wikipedia.org/wiki/British_Steel_%28album%29)
+* [Notepad](http://en.wikipedia.org/wiki/Notepad_%28software%29)
+* [Web workers](http://en.wikipedia.org/wiki/Web_worker)
+* [Crom](http://research.microsoft.com/apps/pubs/default.aspx?id=120939) - James' system for speculative Javascript execution
+* [Speculative execution](http://en.wikipedia.org/wiki/Speculative_execution)
+* [Total recall](http://en.wikipedia.org/wiki/Total_Recall_%281990_film%29)
+* [Firebug](http://en.wikipedia.org/wiki/Firebug_%28software%29)
+* [Galactus](http://en.wikipedia.org/wiki/Galactus)
+* [Odin](http://en.wikipedia.org/wiki/Odin)
+* [The Shellshock bug](http://en.wikipedia.org/wiki/Shellshock_%28software_bug%29)
+* [Turtles all the way down](http://en.wikipedia.org/wiki/Turtles_all_the_way_down)
+* [Jquery](http://en.wikipedia.org/wiki/JQuery)
+* [Angular](http://en.wikipedia.org/wiki/AngularJS)
+* [XHR](http://en.wikipedia.org/wiki/XMLHttpRequest)
+* [MDN](https://developer.mozilla.org/en-US/) - Mozilla developer network, great source of Javascript and browser API documentation
+* [Git](http://en.wikipedia.org/wiki/Git_%28software%29)
+* [The grandfather paradox](http://en.wikipedia.org/wiki/Grandfather_paradox)
+* [Polyfill](http://en.wikipedia.org/wiki/Polyfill)
+* [asm.js](http://en.wikipedia.org/wiki/Asm.js)
+* [NoSQL](http://en.wikipedia.org/wiki/NoSQL)
+* [Mongodb](http://en.wikipedia.org/wiki/MongoDB)
+* [Bare metal](http://en.wikipedia.org/wiki/Bare_machine)
+* [Just in time compiler](http://en.wikipedia.org/wiki/Just-in-time_compilation)
+* [Maslow's hierarchy of needs](http://en.wikipedia.org/wiki/Maslow's_hierarchy_of_needs)
+* [let-satement](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/let)
+* [Zeus](http://en.wikipedia.org/wiki/Zeus)
+* [Quirksmode.org](http://www.quirksmode.org/)
+* [Yo](http://en.wikipedia.org/wiki/Yo_%28app%29)
+* [Leviticus](http://en.wikipedia.org/wiki/Book_of_Leviticus)
+* [Registry](http://en.wikipedia.org/wiki/Windows_Registry)
+* [ASCII art](http://en.wikipedia.org/wiki/ASCII_art)
+* [About:config](http://kb.mozillazine.org/About:config)
+* [Max TCP connections](http://stackoverflow.com/questions/2332741/what-is-the-theoretical-maximum-number-of-open-tcp-connections-that-a-modern-lin)
+* [Shockwave](http://en.wikipedia.org/wiki/Adobe_Shockwave)
+* [Singularity](http://en.wikipedia.org/wiki/Technological_singularity)
+* [DVR](http://en.wikipedia.org/wiki/Digital_video_recorder) - Digital video recorder
+* [Futures](http://en.wikipedia.org/wiki/Futures_contract)
+* [Bendgate](http://en.wikipedia.org/wiki/IPhone_6#Chassis_bending)
+* [Captain America's shield](http://en.wikipedia.org/wiki/Captain_America's_shield)
+* [Georgia](http://en.wikipedia.org/wiki/Georgia_%28U.S._state%29)
+* [Tomfoolery](http://www.merriam-webster.com/dictionary/tomfoolery)
+* [4chan](http://en.wikipedia.org/wiki/4chan)
+* [Huge sloths](http://www.thesalmons.org/lynn/milodon.jpg)
+
+## Titles ##
+* This is just Hollywood stuff
+* We'll edit this out with CGI
+* What happens on the set
+* #freedom #america
+* What prevents me from being a happy person in life
+* It cheapens the art
+* Homelessness is bad too
+* At least you have hope
+* Do you like iteration?
+* I only increment variables
+* Only go forward
+* Black Gandalf
+* Not just fair or balanced
+* Otto von Hyphen
+* We laugh to stop from crying
+* Darkness is delightful
+* The great thing about scandinavian death metal
+* What would Beelzebub do?
+* That TV is in the cloud now
+* Like jazz musicians
+* Like trying to write Inception 2
+* The left hand of satan
+* Multiple speculative universes
+* What universe am I in?
+* A low-rent Stephen Hawking
+* Firebug had no notion of my separate universes
+* The Odin object
+* In the regular development world
+* Chicanery all the way down
+* Function calls are not our strong point
+* Not nothing will happen
+* XHR:s over passenger pidgeon
+* LOL I took a hard dependency on it
+* It's very difficult to make a joke in this space
+* We don't even issue writes
+* devnulldb
+* But we have hoverboards
+* Tread carefully on the polyfills
+* Close the tab and reboot the machine
+* This is such a character builder
+* Mumblefoo.js
+* Fast Javascript, and cancer
+* No-lock cancer
+* Asynchronous cancer
+* That kitten on a tradmill is not going to watch itself
+* Another special type of disaster
+* Folk wisdom on the web
+* 127i content
+* Emu futures
+* If I had a website, I'd run it like Singapore
+* Every computer should come with an old person
+* This whole alternate semantic reality

--- a/content/international/83.md
+++ b/content/international/83.md
@@ -1,0 +1,97 @@
++++
+date = 2014-12-30T10:26:14Z
+draft = false
+title = "Kodsnack 83 - Easy by virtue of travelling the hard way"
+slug = "83"
+aliases = ["/blog/2014/12/30/83"]
+categories = ["avsnitt"]
+audiofile = "https://traffic.libsyn.com/kodsnack/Rob_Ashton.mp3"
+libsynid = "3247160"
+english = true
+audiosize = "29939388"
+audiolength = "30:32"
++++
+
+We chat with [Rob Ashton](http://codeofrob.com/), freelance developer, speaker and recent discoverer of how to learn things properly, live on stage during [Øredev](http://www.oredev.org) 2014. Topics include learning, the plateaus of learning and how to actually do things right to keep evolving and learning. The problems of frameworks wanting to make X easy. Perhaps we should learn about programming in general instead of learning the next big framework in the hope that it will solve our problems without us needing to understand them?
+
+This recording exists as good as it is thanks to [Stephen Chin](http://steveonjava.com/) of [nighthacking.com](http://nighthacking.com/) for providing and masterfully wrangling all the necessary technology.
+
+Comments, thoughts or suggestions? [Discuss this episode](http://techworld.idg.se/2.2524/1.603280/) at Techworld!
+
+## Links ##
+* [Rob Ahston](http://codeofrob.com/)
+* [Rob's keynote from At the frontend](http://vimeo.com/110972838)
+* [Haskell](https://www.haskell.org/haskellwiki/Haskell)
+* [Clojure](http://clojure.org/)
+* [Rob's good use of the guitar](http://oredev.org/2014/sessions/all-about-that-spec)
+* [Strumming](http://en.wikipedia.org/wiki/Strum)
+* [Deliberate learning](http://en.wikipedia.org/wiki/Practice_%28learning_method%29#Deliberate_practice)
+* [Refactoring to to functional](http://oredev.org/2014/sessions/refactoring-to-functional) - talk at Øredev by Hadi Hariri
+* [Datagrid](http://msdn.microsoft.com/en-us/library/system.windows.controls.datagrid%28v=vs.110%29.aspx)
+* [Winforms](http://en.wikipedia.org/wiki/Windows_Forms)
+* [ATS](http://www.ats-lang.org/)
+* [Erlang](http://en.wikipedia.org/wiki/Erlang_%28programming_language%29)
+* [Prolog](http://en.wikipedia.org/wiki/Prolog)
+* [Recursion](http://en.wikipedia.org/wiki/Recursion)
+* [Fold](https://www.haskell.org/haskellwiki/Fold)
+* [Haskell generator functions](https://www.haskell.org/haskellwiki/List_comprehension)
+* [Polymorphism](http://en.wikipedia.org/wiki/Polymorphism_%28computer_science%29)
+* [gen_server](http://www.erlang.org/doc/man/gen_server.html)
+* [MUD](http://en.wikipedia.org/wiki/MUD)
+* [You are in a maze of twisty little passages, all alike](http://en.wikipedia.org/wiki/Colossal_Cave_Adventure)
+* [Latency](http://en.wikipedia.org/wiki/Latency_%28engineering%29)
+* [Macros in MUDs](https://www.zuggsoft.com/zmud/help6/Intr0197.htm)
+* [Wizards in MUDs](http://en.wikipedia.org/wiki/Wizard_%28MUD%29)
+* [Angular](https://angularjs.org/)
+* [Angular 2.0 talk](http://vimeo.com/110973785)
+* [Haskell is lazy](https://www.haskell.org/haskellwiki/Haskell/Lazy_evaluation)
+* [Web forms](http://www.asp.net/web-forms)
+* [npm](https://www.npmjs.com/) - the Node package manager
+* [React](http://facebook.github.io/react/)
+* [Om](https://github.com/swannodette/om)
+* [Clojurescript](https://github.com/clojure/clojurescript)
+* [REPL](http://en.wikipedia.org/wiki/Read%E2%80%93eval%E2%80%93print_loop)
+* [Flux](https://facebook.github.io/flux/) - Facebook's architechture style used by them with React
+* [Ember](http://emberjs.com/)
+* [Bash](http://en.wikipedia.org/wiki/Bash_%28Unix_shell%29)
+* [AWK](http://en.wikipedia.org/wiki/AWK)
+* [SED](http://en.wikipedia.org/wiki/Sed)
+* [Purescript](http://www.purescript.org/)
+* [Cloud Haskell](https://www.haskell.org/haskellwiki/Cloud_Haskell)
+* [Docker](http://en.wikipedia.org/wiki/Docker_%28software%29)
+
+## Titles ##
+* I haven't got an elevator pitch for myself at the moment
+* I've become a real person living in the real world
+* It has changed the way I approach learning
+* I just build software every single day
+* Tangible and listenable
+* A transformative moment
+* Fingerpicking and scales
+* Competent throwing things together
+* I wouldn't say my day job betters me
+* Why am I learning this crappy pointer stuff
+* Deliberate learning
+* Easy by virtue of travelling the hard way
+* My day job is mostly Erlang with a hint of C
+* Erlang is acutally incredibly boring
+* Lisp with horrible syntax
+* Things that mutate in the background
+* The world becomes a happy place
+* I've started writing a MUD in Haskell
+* And then you die in the next scene
+* A problem that noone has anymore
+* It's good for you imagination
+* Factory providers and god knows what else
+* Hate's a very strong word
+* The framework ain't gonna help you
+* Shortcutting problems
+* I don't do prescriptive
+* Preferable to gouge my eyes out with a spoon
+* That "wonderful" is sarcastic
+* It was an abomination
+* If there is such a thing as good C
+* Transcoding and cloud nonsense
+* That's because you skipped the learning step
+* Copying and pasting things off of the internet
+* Shuffling piles of binary around the place

--- a/layouts/international/single.html
+++ b/layouts/international/single.html
@@ -1,0 +1,39 @@
+{{ template "theme/chrome/head.html" . }}
+<body>
+  {{ template "theme/chrome/sidebar.html" . }}
+  <div class="content container">
+    <div class="post">
+      <h1 class="post-title">{{ .Title }}</h1>
+      <span class="post-date">{{ .Date.Format "2006-01-02 15:04" }}</span>
+
+      {{ if .Params.libsynid }}
+      <div class="post-player">
+<iframe style="border: none" src="//html5-player.libsyn.com/embed/episode/id/{{ .Params.libsynid }}/height/45/width/300/theme/standard-mini/direction/no/autoplay/no/autonext/no/thumbnail/no/preload/no/no_addthis/no/" height="45" width="300" scrolling="no"  allowfullscreen webkitallowfullscreen mozallowfullscreen oallowfullscreen msallowfullscreen></iframe>
+      </div>
+      {{ end }}
+
+      {{ if .Params.audiofile }}
+      <span class="post-download"><a href="{{ .Params.audiofile }}">Ladda ner (mp3)</a></span>
+      <script>
+        var linksInNewTab = false;
+        var toggleLinkTarget = function () {
+          linksInNewTab = !linksInNewTab;
+          var links = document.getElementsByTagName('a');
+          var numLinks = links.length;
+          for (var i = 0; i < numLinks; i++) {
+            links.item(i).target = linksInNewTab ? '_blank' : '';
+          }
+        }
+        document.addEventListener("DOMContentLoaded", function () {
+          document.getElementById('linkToggler').addEventListener('click', toggleLinkTarget);
+        });
+      </script>
+      <span class="open-in-tabs"><label><input type="checkbox" label="Öppna länkar i nya flikar" id="linkToggler">Öppna länkar i nya flikar</input></label></span>
+      {{ end }}
+
+      {{ .Content }}
+
+    </div>
+  </div>
+  </body>
+</html>

--- a/layouts/section/international.html
+++ b/layouts/section/international.html
@@ -12,7 +12,7 @@
       </p>
 
       <ul class="posts">
-        {{ range where .Data.Pages "Section" "avsnitt"  }}
+        {{ range where .Data.Pages "Section" "international"  }}
             {{ if .Params.english }}
             <li>
               <span class="post-list">

--- a/layouts/section/international.rss.xml
+++ b/layouts/section/international.rss.xml
@@ -31,7 +31,7 @@
         </itunes:owner>
         <itunes:summary>All the English episodes of Kodsnack - a podcast by developers, about anything interesting to developers</itunes:summary>
         <itunes:subtitle>A podcast by developers, about anything interesting to developers</itunes:subtitle>
-        {{ range where .Data.Pages "Section" "avsnitt" }}{{ if .Params.english}}
+        {{ range where .Data.Pages "Section" "international" }}{{ if .Params.english}}
             <item>
                 <title>{{ .Title }} </title>
                 <pubDate>{{ .Date.Format "02 Jan 2006 15:04 -0700" | safeHTML }}</pubDate>


### PR DESCRIPTION
Ni sa i senaste avsnittet att ni hade problem med Hugo-generering av er engelska feed. Har haft ett något liknande fel en gång och minns att jag gjorde en enkel fix i linje med den här PR:en för att slippa förstå varför det egentligen skedde.

Det som görs är att layout-filen för international-sidan och feeden hämtar från `content/international` istället och i `Makefile` görs kopiering av alla Markdowns i `content/avsnitt` med `english = true` till `content/international`.

Inte highbrow precis, men funktionellt nog för att lösa detta problem kanske.