### PR TITLE
405: Corrected spelling of lastname for Olle

### DIFF
--- a/content/avsnitt/405.md
+++ b/content/avsnitt/405.md
@@ -41,7 +41,7 @@ Gillar du Kodsnack får du hemskt gärna [recensera oss i iTunes](http://itunes.
 * [Mats Nordkvist](http://cobol.se/About_cobol.se.html)
 * [376](https://kodsnack.se/376/) och [377](https://kodsnack.se/377/) - tidigare avsnitt med Mats och Erik
 * [Olle Westergård](https://www.linkedin.com/in/olle-westerg%C3%A5rd-256a59/)
-* [378](https://kodsnack.se/378/), [379](https://kodsnack.se/379/) och [397](https://kodsnack.se/397/) - avsnitt med Olle Westergårdf
+* [378](https://kodsnack.se/378/), [379](https://kodsnack.se/379/) och [397](https://kodsnack.se/397/) - avsnitt med Olle Westergård
 * [COBOL](https://en.wikipedia.org/wiki/COBOL)
 * [SEB](https://sv.wikipedia.org/wiki/Skandinaviska_Enskilda_Banken)
 * [COBOL academy](https://www.cobolfactory.se/cobol-utbildning-cobolskola-kurs/)


### PR DESCRIPTION
Trailing f removed.