### PR TITLE
fix typo kodsnackpodcastuniver.se

### DIFF
--- a/content/avsnitt/531.md
+++ b/content/avsnitt/531.md
@@ -30,7 +30,7 @@ Gillar du Kodsnack får du hemskt gärna [recensera oss i iTunes](https://itunes
 ## Länkar ##
 * [Anton](https://twitter.com/Awnton)
 * [Asdf](https://asdf.pizza/)
-* [kodsnackpodcastsuniver.se](https://kodsnackpodcastuniver.se/)
+* [kodsnackpodcastuniver.se](https://kodsnackpodcastuniver.se/)
 * [kodsnackpodcastuniver.se på Github](https://github.com/anton-g/kpu)
 * [IDG](https://en.wikipedia.org/wiki/International_Data_Group)
 * [174](https://kodsnack.se/174/) - ett [Code night](https://techworld.event.idg.se/event/codenight-6/)-avsnitt


### PR DESCRIPTION
tar bort ett överskotts s i kodsnackpodcast**s**univer.se