### PR TITLE
Ändra haskell kod från citat till kod

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -4,6 +4,8 @@ title = "Kodsnack - podd av kodare, för kodare, på svenska"
 pluralizeListTitles = false
 
 [markup]
+  [markup.highlight]
+    noClasses = false
   [markup.goldmark]
     [markup.goldmark.renderer]
       unsafe = true

--- a/content/avsnitt/603.md
+++ b/content/avsnitt/603.md
@@ -23,18 +23,20 @@ Vi reder också ut vem som är äldst av Andreas, Haskell, och Erlang. Samt varf
 
 Lite exempelkod:
 
->sumAllNumbers :: String -> Int
->
->sumAllNumbers str = sum (map read (lines str))
->
->
->main :: IO ()
->
->main = do
->
->  fileContent <- readFile "magiska_tal.txt"
->
->  print (sumAllNumbers fileContent)
+```haskell
+sumAllNumbers :: String -> Int
+
+sumAllNumbers str = sum (map read (lines str))
+
+
+main :: IO ()
+
+main = do
+
+  fileContent <- readFile "magiska_tal.txt"
+
+  print (sumAllNumbers fileContent)
+```
 
 Ett stort tack till [Cloudnet](https://www.cloudnet.se) som sponsrar vår [VPS](https://en.wikipedia.org/wiki/Virtual_private_server)!
 


### PR DESCRIPTION
Hej, här är två [förbindelser](https://github.com/bjorne/git-pa-svenska) som ändrar
![image](https://github.com/user-attachments/assets/c7e8f693-43c6-4d8b-b4ea-9b7255749e46)
till
![image](https://github.com/user-attachments/assets/cccde8b6-b559-420f-8c10-1c00d21f875a)
